### PR TITLE
Allow CuPy 7

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - python
   run:
     - cudatoolkit ={{ cuda_version }}.*
-    - cupy>=6.6.0,<7
+    - cupy>=6.6.0,<8
     - nccl =2.5.*
     - numba ={{ numba_version }}.*
     - numpy>={{ numpy_version }}.*


### PR DESCRIPTION
cuML now [requires CuPy 7+]( https://github.com/rapidsai/cuml/blob/0d8923f805cd713128c8b04a2a81ecad96c9d17a/conda/recipes/cuml/meta.yaml#L43 ). So this relax the constraint here for cuML.

xref: https://github.com/rapidsai/cuml/pull/1762

cc @JohnZed