### PR TITLE
Add new test meta-pkg, removing test dependencies from build meta-pkg

### DIFF
--- a/conda/recipes/rapids-test-env/meta.yaml
+++ b/conda/recipes/rapids-test-env/meta.yaml
@@ -1,0 +1,93 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+
+{% set version = environ.get('RAPIDS_VERSION', '0.0.0.dev') %}
+{% set minor_version = version.split('.')[0] + '.' + version.split('.')[1] %}
+{% set build_offset = environ.get('RAPIDS_OFFSET', 0) %}
+{% set cuda_version = '.'.join(environ.get('CUDA_VERSION', '9.2').split('.')[:2]) %}
+{% set py_version = environ.get('CONDA_PY', 36) %}
+
+package:
+  name: rapids-test-env
+  version: {{ version }}
+
+source:
+  path: .
+
+build:
+  number: {{ build_offset }}
+  string: cuda{{ cuda_version }}_py{{ py_version }}_{{ build_offset }}
+  script_env:
+    - RAPIDS_VERSION
+    - RAPIDS_OFFSET
+    - CUDA_VERSION
+
+requirements:
+  host:
+    - python
+  run:
+    - arrow-cpp =0.15.0
+    - black
+    - conda-forge::blas=2.14=openblas
+    - boost-cpp =1.70.0
+    - boto3
+    - cmake =3.14.5
+    - cmake_setuptools >=0.1.3
+    - conda =4.7.12
+    - conda-build =3.18.11
+    - conda-verify =3.1.1
+    - cudatoolkit ={{ cuda_version }}.*
+    - cupy >=6.6.0,<8.0.0a0,!=7.1.0
+    - cython >=0.29,<0.30
+    - dask >=2.1.0
+    - distributed >=2.1.0
+    - dlpack =0.2
+    - double-conversion =3.1.5
+    - fastavro =0.22.3
+    - flake8
+    - flatbuffers =1.10.0
+    - gcsfs
+    - gdal =2.4.*
+    - git
+    - graphviz
+    - httpretty
+    - hypothesis
+    - isort
+    - lapack
+    - rapidsai::libclang =8.0.0
+    - libcumlprims ={{ minor_version }}.*
+    - libcypher-parser
+    - libgcc-ng =7.3.0
+    - libgfortran-ng =7.3.0
+    - liblapack
+    - librdkafka =1.2.2
+    - libstdcxx-ng =7.3.0
+    - make
+    - moto
+    - nccl =2.5.*
+    - numba >=0.46,<0.47
+    - numpy >=1.17.3.*
+    - pandas >=0.25,<0.26
+    - protobuf >=3.4.1,<4.0.0
+    - pyarrow =0.15.0
+    - pytest
+    - pytest-cov
+    - python
+    - rapidjson =1.1.0
+    - ripgrep
+    - s3fs
+    - setuptools
+    - scikit-learn =0.21.3
+    - scipy =1.3.0
+    - streamz
+    - twine
+    - ucx-py ={{ minor_version }}.*
+
+about:
+  home: http://rapids.ai/
+  license: Apache-2.0
+  license_file: ../../../LICENSE
+  summary: 'RAPIDS Test Dependencies and Tool Environment Installer'
+  description: |
+    Meta-package for installing test dependencies and tools needed to test all RAPIDS libraries.
+  doc_url: https://docs.rapids.ai/
+  dev_url: https://github.com/rapidsai/


### PR DESCRIPTION
Breaking out all test dependencies from `rapids-build-env` to a new meta-pkg `rapids-test-env`