### PR TITLE
FIX Add upper limit for fsspec

### DIFF
--- a/conda/recipes/nightly-versions.yaml
+++ b/conda/recipes/nightly-versions.yaml
@@ -52,7 +52,7 @@ fastavro_version:
 flatbuffers_version:
   - '=1.10.0'
 fsspec_version:
-  - '>=0.3.3'
+  - '>=0.3.3,<0.7.0'
 gdal_version:
   - '=2.4.*'
 ipython_version:

--- a/conda/recipes/nightly-versions.yaml
+++ b/conda/recipes/nightly-versions.yaml
@@ -52,7 +52,7 @@ fastavro_version:
 flatbuffers_version:
   - '=1.10.0'
 fsspec_version:
-  - '>=0.3.3,<0.7.0'
+  - '>=0.3.3,<0.7.0a0'
 gdal_version:
   - '=2.4.*'
 ipython_version:

--- a/conda/recipes/release-versions.yaml
+++ b/conda/recipes/release-versions.yaml
@@ -52,7 +52,7 @@ fastavro_version:
 flatbuffers_version:
   - '=1.10.0'
 fsspec_version:
-  - '>=0.3.3'
+  - '>=0.3.3,<0.7.0'
 gdal_version:
   - '=2.4.*'
 ipython_version:

--- a/conda/recipes/release-versions.yaml
+++ b/conda/recipes/release-versions.yaml
@@ -52,7 +52,7 @@ fastavro_version:
 flatbuffers_version:
   - '=1.10.0'
 fsspec_version:
-  - '>=0.3.3,<0.7.0'
+  - '>=0.3.3,<0.7.0a0'
 gdal_version:
   - '=2.4.*'
 ipython_version:


### PR DESCRIPTION
There are changes in 0.7 that cause dask test failures