### PR TITLE
Match new fsspec version with cudf

### DIFF
--- a/conda/recipes/nightly-versions.yaml
+++ b/conda/recipes/nightly-versions.yaml
@@ -52,7 +52,7 @@ fastavro_version:
 flatbuffers_version:
   - '=1.10.0'
 fsspec_version:
-  - '>=0.3.3,<0.7.0a0'
+  - '>=0.6.0'
 gdal_version:
   - '=2.4.*'
 ipython_version:

--- a/conda/recipes/release-versions.yaml
+++ b/conda/recipes/release-versions.yaml
@@ -52,7 +52,7 @@ fastavro_version:
 flatbuffers_version:
   - '=1.10.0'
 fsspec_version:
-  - '>=0.3.3,<0.7.0a0'
+  - '>=0.6.0'
 gdal_version:
   - '=2.4.*'
 ipython_version:


### PR DESCRIPTION
Will only use this for RAPIDS 0.14+

RAPIDS 0.13 will be released with `>=0.3.3,<0.7.0a` as the patch is only in rapidsai/cudf#4745