### PR TITLE
Add cusignal to the `rapids` meta-pkg

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -45,6 +45,7 @@ requirements:
     - cudf ={{ minor_version }}.*
     - cugraph ={{ minor_version }}.*
     - cuml ={{ minor_version }}.*
+    - cusignal ={{ minor_version }}.*
     - cuspatial ={{ minor_version }}.*
     - dask-cuda ={{ minor_version }}.*
     - dask-xgboost {{ dask_xgboost_version }}


### PR DESCRIPTION
For the 0.13 release `cusignal` will be on the chooser for installs and added to the meta-pkg