### PR TITLE
Add cuxfilter to rapids meta-pkg

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -46,6 +46,7 @@ requirements:
     - cugraph ={{ minor_version }}.*
     - cuml ={{ minor_version }}.*
     - cuspatial ={{ minor_version }}.*
+    - cuxfilter ={{ minor_version }}.*
     - dask-cuda ={{ minor_version }}.*
     - dask-xgboost {{ dask_xgboost_version }}
     - nvstrings ={{ minor_version }}.*


### PR DESCRIPTION
Bringing `cuxfilter` into the meta-pkg for this release