### PR TITLE
FIX Override conda channels for each build

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -41,7 +41,7 @@ conda list --show-channel-urls
 function build_pkg {
   # Build pkg
   gpuci_logger "Start conda build for '${1}'..."
-  conda build -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge \
+  conda build --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge \
               --python=${PYTHON_VER} -m ${CONDA_CONFIG_FILE} ${1}
 }
 

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -41,7 +41,7 @@ conda list --show-channel-urls
 function build_pkg {
   # Build pkg
   gpuci_logger "Start conda build for '${1}'..."
-  conda build --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge \
+  conda build --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge -c defaults \
               --python=${PYTHON_VER} -m ${CONDA_CONFIG_FILE} ${1}
 }
 


### PR DESCRIPTION
This way release builds will only pull packages from `rapidsai` and can alert us to missing packages sooner. Same for nightly builds.