### PR TITLE
replaced libclang with clang and clang-tools packages from conda-forge

### DIFF
--- a/conda/recipes/nightly-versions.yaml
+++ b/conda/recipes/nightly-versions.yaml
@@ -31,6 +31,8 @@ bokeh_version:
   - '=1.*'
 boost_cpp_version:
   - '=1.70.0'
+clang_version:
+  - '=8.*'
 cmake_version:
   - '=3.14.5'
 cmake_setuptools_version:
@@ -59,8 +61,6 @@ ipython_version:
   - '=7.3.*'
 jupyterlab_version:
   - '=1.2.*'
-clang_rapidsai_version:
-  - '=8'
 librdkafka_version:
   - '=1.2.2'
 nccl_version:

--- a/conda/recipes/nightly-versions.yaml
+++ b/conda/recipes/nightly-versions.yaml
@@ -59,8 +59,8 @@ ipython_version:
   - '=7.3.*'
 jupyterlab_version:
   - '=1.2.*'
-libclang_rapidsai_version:
-  - '=8.0.0'
+clang_rapidsai_version:
+  - '=8'
 librdkafka_version:
   - '=1.2.2'
 nccl_version:

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -41,6 +41,8 @@ requirements:
     - conda-forge::blas{{ blas_version }}
     - boost-cpp {{ boost_cpp_version }}
     - boto3
+    - conda-forge::clang {{ clang_version }}
+    - conda-forge::clang-tools {{ clang_version }}
     - cmake {{ cmake_version }}
     - cmake_setuptools {{ cmake_setuptools_version }}
     - conda {{ conda_version }}
@@ -66,8 +68,6 @@ requirements:
     - hypothesis
     - isort
     - lapack
-    - conda-forge::clang {{ clang_rapidsai_version }}
-    - conda-forge::clang-tools {{ clang_rapidsai_version }}
     - libcumlprims ={{ minor_version }}.*
     - libcypher-parser
     - libgcc-ng {{ build_stack_version }}

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -66,7 +66,8 @@ requirements:
     - hypothesis
     - isort
     - lapack
-    - rapidsai::libclang {{ libclang_rapidsai_version }}
+    - conda-forge::clang {{ clang_rapidsai_version }}
+    - conda-forge::clang-tools {{ clang_rapidsai_version }}
     - libcumlprims ={{ minor_version }}.*
     - libcypher-parser
     - libgcc-ng {{ build_stack_version }}

--- a/conda/recipes/release-versions.yaml
+++ b/conda/recipes/release-versions.yaml
@@ -31,6 +31,8 @@ bokeh_version:
   - '=1.*'
 boost_cpp_version:
   - '=1.70.0'
+clang_version:
+  - '=8.*'
 cmake_version:
   - '=3.14.5'
 cmake_setuptools_version:
@@ -59,8 +61,6 @@ ipython_version:
   - '=7.3.*'
 jupyterlab_version:
   - '=1.2.*'
-clang_rapidsai_version:
-  - '=8'
 librdkafka_version:
   - '=1.2.2'
 nccl_version:

--- a/conda/recipes/release-versions.yaml
+++ b/conda/recipes/release-versions.yaml
@@ -59,8 +59,8 @@ ipython_version:
   - '=7.3.*'
 jupyterlab_version:
   - '=1.2.*'
-libclang_rapidsai_version:
-  - '=8.0.0'
+clang_rapidsai_version:
+  - '=8'
 librdkafka_version:
   - '=1.2.2'
 nccl_version:


### PR DESCRIPTION
This is in addition to the PR https://github.com/rapidsai/gpuci-build-environment/pull/68 as per @mike-wendt 's suggestion on that PR.