### PR TITLE
Bump dask version

### DIFF
--- a/conda/recipes/nightly-versions.yaml
+++ b/conda/recipes/nightly-versions.yaml
@@ -42,9 +42,9 @@ cupy_version:
 cython_version:
   - '>=0.29,<0.30'
 dask_version:
-  - '>=2.12.0'
+  - '>=2.15.0'
 distributed_version:
-  - '>=2.12.0'
+  - '>=2.15.0'
 dlpack_version:
   - '=0.2'
 double_conversion_version:


### PR DESCRIPTION
Bump dask/distributed to match cudf change: https://github.com/rapidsai/cudf/pull/4947