### PR TITLE
Bump Numba version to 0.49

### DIFF
--- a/conda/recipes/nightly-versions.yaml
+++ b/conda/recipes/nightly-versions.yaml
@@ -68,7 +68,7 @@ nccl_version:
 networkx_version:
   - '>=2.3'
 numba_version:
-  - '>=0.48,<0.49'
+  - '>=0.49'
 numpy_version:
   - '>=1.17.3'
 pandas_version:


### PR DESCRIPTION
This changes the Numba version to be at least 0.49. The previous version specification, >=0.48,<0.49 was due to API changes in Numba 0.49 that could have affected RAPIDS libraries - I have tested current versions of cuDF, Dask-cuDF, cuGraph, cuSpatial, and cuML with 0.49 without any issues relating to the changes in version 0.49 of Numba.

There are no backwards-incompatible changes planned for Numba 0.50 (for non-deprecated functionality), and no deprecated Numba features are used by RAPIDS as far as I am aware - hence, I think it is appropriate to also allow versions of Numba > 0.49.