### PR TITLE
[REVIEW] Update xgboost nightly version

### DIFF
--- a/conda/recipes/nightly-versions.yaml
+++ b/conda/recipes/nightly-versions.yaml
@@ -8,7 +8,7 @@ dask_xgboost_version:
 
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
-  - '=1.0.2dev.rapidsai0.14'
+  - '=1.1.0dev.rapidsai0.14'
 
 # Versions for conda
 conda_version:


### PR DESCRIPTION
New xgboost packages available: https://anaconda.org/rapidsai-nightly/xgboost/files?version=1.1.0dev.rapidsai0.14