### PR TITLE
Add doc customization dependencies

### DIFF
--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -6,14 +6,14 @@
 {% set cuda_version = '.'.join(environ.get('CUDA_VERSION', '10.0').split('.')[:2]) %}
 {% set py_version = environ.get('CONDA_PY', 36) %}
 
-### 
+###
 # Versions referenced below are set in `conda/recipe/*versions.yaml` except for
 #   those set above (e.g. `cuda_version`)
 #
-# gpuCI loads the correct file based on the build type (NIGHTLY or RELEASE) in 
+# gpuCI loads the correct file based on the build type (NIGHTLY or RELEASE) in
 #   `ci/cpu/build.sh` and `ci/axis/*.yaml`
 #
-# Manual builds need to use the `conda build` flag of `-m <path-to-file>.yaml` 
+# Manual builds need to use the `conda build` flag of `-m <path-to-file>.yaml`
 #   to set these versions
 ###
 
@@ -39,7 +39,9 @@ requirements:
     - python
     - pip
   run:
+    - beautifulsoup4
     - doxygen
+    - jq
     - nbsphinx
     - numpydoc
     - pandoc {{ pandoc_version }}


### PR DESCRIPTION
This PR adds the necessary dependencies for our documentation [customization scripts](https://github.com/rapidsai/docs/tree/master/customization).

Not sure if we want these deps in the `rapids-doc-env` environment since Ops is the only people who will use them, but I figured I'd open the PR to raise the discussion.