### PR TITLE
[REVIEW] Add markdown to docs dependencies

### DIFF
--- a/conda/recipes/nightly-versions.yaml
+++ b/conda/recipes/nightly-versions.yaml
@@ -56,7 +56,7 @@ flatbuffers_version:
 fsspec_version:
   - '>=0.6.0'
 gdal_version:
-  - '=2.4.*'
+  - '>=3.0.2'
 ipython_version:
   - '=7.3.*'
 jupyterlab_version:

--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - pip
   run:
     - doxygen
+    - markdown
     - nbsphinx
     - numpydoc
     - pandoc {{ pandoc_version }}


### PR DESCRIPTION
Error in docs, sphinx-markdown-tables depends on markdown but doesn't install it for some reason. This fixes it.

```
06:28:52 Exception occurred:
06:28:52   File "/opt/conda/envs/rapids/lib/python3.7/site-packages/sphinx_markdown_tables/__init__.py", line 22, in process_tables
06:28:52     import markdown
06:28:52 ModuleNotFoundError: No module named 'markdown'
```