### PR TITLE
[REVIEW] Add spdlog to rapids-build-env

### DIFF
--- a/conda/recipes/nightly-versions.yaml
+++ b/conda/recipes/nightly-versions.yaml
@@ -83,3 +83,5 @@ scikit_learn_version:
   - '=0.21.3'
 scipy_version:
   - '=1.3.0'
+spdlog_version
+  - '>=1.4.2'

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -97,6 +97,7 @@ requirements:
     - scikit-learn {{ scikit_learn_version }}
     - scipy {{ scipy_version }}
     - shellcheck
+    - spdlog {{ spdlog_version }}
     - statsmodels
     - streamz
     - twine

--- a/conda/recipes/release-versions.yaml
+++ b/conda/recipes/release-versions.yaml
@@ -83,3 +83,5 @@ scikit_learn_version:
   - '=0.21.3'
 scipy_version:
   - '=1.3.0'
+spdlog_version
+  - '>=1.4.2'


### PR DESCRIPTION
Required when building RMM Cython.

PR introducing this requirement: https://github.com/rapidsai/rmm/pull/363