### PR TITLE
Add spdlog to build-env

### DIFF
--- a/conda/recipes/nightly-versions.yaml
+++ b/conda/recipes/nightly-versions.yaml
@@ -83,3 +83,5 @@ scikit_learn_version:
   - '=0.23.0'
 scipy_version:
   - '=1.3.0'
+spdlog_version:
+  - '=1.6.0'

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -97,7 +97,7 @@ requirements:
     - scikit-learn {{ scikit_learn_version }}
     - scipy {{ scipy_version }}
     - shellcheck
-    - spdlog 1.6.0
+    - spdlog {{ spdlog_version }}
     - statsmodels
     - streamz
     - twine

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -97,6 +97,7 @@ requirements:
     - scikit-learn {{ scikit_learn_version }}
     - scipy {{ scipy_version }}
     - shellcheck
+    - spdlog 1.6.0
     - statsmodels
     - streamz
     - twine

--- a/conda/recipes/release-versions.yaml
+++ b/conda/recipes/release-versions.yaml
@@ -83,3 +83,5 @@ scikit_learn_version:
   - '=0.23.0'
 scipy_version:
   - '=1.3.0'
+spdlog_version:
+  - '=1.6.0'


### PR DESCRIPTION
This PR adds `spdlog` to the `build-env` as a temporary workaround to get `rmm` building correctly.