### PR TITLE
Add nodejs version spec for notebook-env

### DIFF
--- a/conda/recipes/nightly-versions.yaml
+++ b/conda/recipes/nightly-versions.yaml
@@ -67,6 +67,8 @@ nccl_version:
   - '=2.5.*'
 networkx_version:
   - '>=2.3'
+nodejs_version:
+  - '>=12'
 numba_version:
   - '>=0.49'
 numpy_version:

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -47,7 +47,7 @@ requirements:
     - jupyterlab {{ jupyterlab_version }}
     - matplotlib
     - networkx
-    - nodejs
+    - nodejs {{ nodejs_version }}
     - pytest
     - scikit-learn {{ scikit_learn_version }}
     - scipy {{ scipy_version }}

--- a/conda/recipes/release-versions.yaml
+++ b/conda/recipes/release-versions.yaml
@@ -67,6 +67,8 @@ nccl_version:
   - '=2.5.*'
 networkx_version:
   - '>=2.3'
+nodejs_version:
+  - '>=12'
 numba_version:
   - '>=0.49,<0.50a'
 numpy_version:


### PR DESCRIPTION
This PR adds a _NodeJS_ version spec to prevent devel builds from breaking. Version 12 is current NodeJS LTS version https://nodejs.org/en/download/