### PR TITLE
[WIP] Add CUDA 11 for env-pkg builds

### DIFF
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -5,7 +5,7 @@ CONDA_CONFIG_FILE:
   - conda/recipes/nightly-versions.yaml
 
 RAPIDS_VER:
-  - 0.15.0
+  - 0.15
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -9,6 +9,7 @@ RAPIDS_VER:
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
+  - 11.0
   - 10.2
   - 10.1
   - 10.0

--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -15,7 +15,7 @@ CUDA_VER:
   - 10.0
 
 DEFAULT_CUDA_VER:
-  - 10.0
+  - 10.1
 
 PYTHON_VER:
   - 3.6

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -5,7 +5,7 @@ CONDA_CONFIG_FILE:
   - conda/recipes/release-versions.yaml
 
 RAPIDS_VER:
-  - 0.15.0
+  - 0.15
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -5,7 +5,7 @@ CONDA_CONFIG_FILE:
   - conda/recipes/release-versions.yaml
 
 RAPIDS_VER:
-  - 0.14.0
+  - 0.15.0
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -9,6 +9,7 @@ RAPIDS_VER:
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
+  - 11.0
   - 10.2
   - 10.1
   - 10.0

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -15,7 +15,7 @@ CUDA_VER:
   - 10.0
 
 DEFAULT_CUDA_VER:
-  - 10.0
+  - 10.1
 
 PYTHON_VER:
   - 3.6

--- a/ci/cpu/build-env.sh
+++ b/ci/cpu/build-env.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Copyright (c) 2020, NVIDIA CORPORATION.
+###############################################################
+# rapids environment pkg conda build script for gpuCI         #
+#                                                             #
+# config set in `ci/axis/*.yml`                               #
+###############################################################
+set -e
+
+# Set paths
+export PATH=/conda/bin:$PATH
+export HOME=$WORKSPACE
+
+# Save original build offset
+export ORIG_OFFSET=$RAPIDS_OFFSET
+
+# Set recipe paths
+CONDA_RAPIDS_BUILD_RECIPE="conda/recipes/rapids-build-env"
+CONDA_RAPIDS_NOTEBOOK_RECIPE="conda/recipes/rapids-notebook-env"
+CONDA_RAPIDS_DOC_RECIPE="conda/recipes/rapids-doc-env"
+
+# Activate conda env
+source activate base
+
+# Print current env vars
+env
+
+# Install gpuCI tools
+curl -s https://raw.githubusercontent.com/rapidsai/gpuci-tools/master/install.sh | bash
+source ~/.bashrc
+cd ~
+
+# Print diagnostic information
+gpuci_logger "Print conda info..."
+conda info
+conda config --show-sources
+conda list --show-channel-urls
+
+# Setup build env
+gpuci_logger "Install tools for build..."
+gpuci_retry conda install -y -c conda-forge conda-build conda-verify ripgrep anaconda-client
+conda list
+
+function build_pkg {
+  # Build pkg
+  gpuci_logger "Start conda build for '${1}'..."
+  conda build --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge -c defaults \
+              --python=${PYTHON_VER} -m ${CONDA_CONFIG_FILE} ${1}
+}
+
+function build_default_pkg {
+  # Build default version if current version matches DEFAULT_CUDA_VER
+  if [ "$CUDA_VER" == "$DEFAULT_CUDA_VER" ] ; then
+    gpuci_logger "Current CUDA_VER '$CUDA_VER' is the DEFAULT_CUDA_VER, building package again with incremented build number..."
+    gpuci_logger "Previous build number '$RAPIDS_OFFSET'"
+    export RAPIDS_OFFSET=$((RAPIDS_OFFSET+1))
+    gpuci_logger "New build number '$RAPIDS_OFFSET'"
+    build_pkg $1
+    # Reset offset
+    export RAPIDS_OFFSET=$ORIG_OFFSET
+    gpuci_logger "Reset build number after default build '$RAPIDS_OFFSET'"
+  else
+    gpuci_logger "Current CUDA_VER '$CUDA_VER' is not DEFAULT_CUDA_VER, skipping default build..."
+  fi
+}
+
+function run_builds {
+  # Kick off main pkg b
+  build_pkg $1
+  # Check and build default pkgs
+  build_default_pkg $1
+}
+
+function upload_builds {
+  # Check for upload key
+  if [ -z "$MY_UPLOAD_KEY" ]; then
+    gpuci_logger "No upload key found, env var MY_UPLOAD_KEY not set, skipping upload..."
+  else
+    gpuci_logger "Upload key found, starting upload..."
+    gpuci_logger "Files to upload..."
+    ls /conda/conda-bld/linux-64/rapids*.tar.bz2
+
+    gpuci_logger "Starting upload..."
+    ls /conda/conda-bld/linux-64/rapids*.tar.bz2 | xargs gpuci_retry \
+      anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai-nightly} --label main --skip-existing
+  fi
+}
+
+# Run builds
+run_builds $CONDA_RAPIDS_BUILD_RECIPE
+run_builds $CONDA_RAPIDS_NOTEBOOK_RECIPE
+run_builds $CONDA_RAPIDS_DOC_RECIPE
+
+# Upload builds
+upload_builds

--- a/ci/cpu/build-env.sh
+++ b/ci/cpu/build-env.sh
@@ -19,6 +19,9 @@ CONDA_RAPIDS_BUILD_RECIPE="conda/recipes/rapids-build-env"
 CONDA_RAPIDS_NOTEBOOK_RECIPE="conda/recipes/rapids-notebook-env"
 CONDA_RAPIDS_DOC_RECIPE="conda/recipes/rapids-doc-env"
 
+# Allow insecure connections for conda-mirror
+echo "ssl_verify: False" >> /conda/.condarc
+
 # Activate conda env
 source activate base
 

--- a/ci/cpu/build-env.sh
+++ b/ci/cpu/build-env.sh
@@ -41,13 +41,13 @@ conda list --show-channel-urls
 
 # Setup build env
 gpuci_logger "Install tools for build..."
-gpuci_retry conda install -y -c conda-forge conda-build conda-verify ripgrep anaconda-client
+gpuci_retry conda install -y -k -c conda-forge conda-build conda-verify ripgrep anaconda-client
 conda list
 
 function build_pkg {
   # Build pkg
   gpuci_logger "Start conda build for '${1}'..."
-  conda build --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge -c defaults \
+  conda build -k --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge -c defaults \
               --python=${PYTHON_VER} -m ${CONDA_CONFIG_FILE} ${1}
 }
 

--- a/ci/cpu/build-env.sh
+++ b/ci/cpu/build-env.sh
@@ -41,13 +41,13 @@ conda list --show-channel-urls
 
 # Setup build env
 gpuci_logger "Install tools for build..."
-gpuci_retry conda install -y -k -c conda-forge conda-build conda-verify ripgrep anaconda-client
+gpuci_retry conda install -y -c conda-forge conda-build conda-verify ripgrep anaconda-client
 conda list
 
 function build_pkg {
   # Build pkg
   gpuci_logger "Start conda build for '${1}'..."
-  conda build -k --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge -c defaults \
+  conda build --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge -c defaults \
               --python=${PYTHON_VER} -m ${CONDA_CONFIG_FILE} ${1}
 }
 

--- a/ci/cpu/build-meta.sh
+++ b/ci/cpu/build-meta.sh
@@ -17,12 +17,9 @@ export ORIG_OFFSET=$RAPIDS_OFFSET
 # Set recipe paths
 CONDA_XGBOOST_RECIPE="conda/recipes/rapids-xgboost"
 CONDA_RAPIDS_RECIPE="conda/recipes/rapids"
-CONDA_RAPIDS_BUILD_RECIPE="conda/recipes/rapids-build-env"
-CONDA_RAPIDS_NOTEBOOK_RECIPE="conda/recipes/rapids-notebook-env"
-CONDA_RAPIDS_DOC_RECIPE="conda/recipes/rapids-doc-env"
 
 # Activate conda env
-source activate gdf
+source activate base
 
 # Print current env vars
 env
@@ -37,6 +34,11 @@ gpuci_logger "Print conda info..."
 conda info
 conda config --show-sources
 conda list --show-channel-urls
+
+# Setup build env
+gpuci_logger "Install tools for build..."
+gpuci_retry conda install -y -c conda-forge conda-build conda-verify ripgrep anaconda-client
+conda list
 
 function build_pkg {
   # Build pkg
@@ -84,8 +86,6 @@ function upload_builds {
 }
 
 # Run builds
-run_builds $CONDA_XGBOOST_RECIPE
-run_builds $CONDA_RAPIDS_RECIPE
 run_builds $CONDA_RAPIDS_BUILD_RECIPE
 run_builds $CONDA_RAPIDS_NOTEBOOK_RECIPE
 run_builds $CONDA_RAPIDS_DOC_RECIPE

--- a/ci/cpu/build-meta.sh
+++ b/ci/cpu/build-meta.sh
@@ -40,13 +40,13 @@ conda list --show-channel-urls
 
 # Setup build env
 gpuci_logger "Install tools for build..."
-gpuci_retry conda install -k -y -c conda-forge conda-build conda-verify ripgrep anaconda-client
+gpuci_retry conda install -y -c conda-forge conda-build conda-verify ripgrep anaconda-client
 conda list
 
 function build_pkg {
   # Build pkg
   gpuci_logger "Start conda build for '${1}'..."
-  conda build -k --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge -c defaults \
+  conda build --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge -c defaults \
               --python=${PYTHON_VER} -m ${CONDA_CONFIG_FILE} ${1}
 }
 

--- a/ci/cpu/build-meta.sh
+++ b/ci/cpu/build-meta.sh
@@ -18,6 +18,9 @@ export ORIG_OFFSET=$RAPIDS_OFFSET
 CONDA_XGBOOST_RECIPE="conda/recipes/rapids-xgboost"
 CONDA_RAPIDS_RECIPE="conda/recipes/rapids"
 
+# Allow insecure connections for conda-mirror
+echo "ssl_verify: False" >> /conda/.condarc
+
 # Activate conda env
 source activate base
 

--- a/ci/cpu/build-meta.sh
+++ b/ci/cpu/build-meta.sh
@@ -40,13 +40,13 @@ conda list --show-channel-urls
 
 # Setup build env
 gpuci_logger "Install tools for build..."
-gpuci_retry conda install -y -c conda-forge conda-build conda-verify ripgrep anaconda-client
+gpuci_retry conda install -k -y -c conda-forge conda-build conda-verify ripgrep anaconda-client
 conda list
 
 function build_pkg {
   # Build pkg
   gpuci_logger "Start conda build for '${1}'..."
-  conda build --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge -c defaults \
+  conda build -k --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge -c defaults \
               --python=${PYTHON_VER} -m ${CONDA_CONFIG_FILE} ${1}
 }
 


### PR DESCRIPTION
The meta-pkgs `rapids` and `rapids-xgboost` will not build, but the env-pkgs should build. Having these in place along with updates to rapidsai/gpuci-build-environment will allow us to get gpuCI CUDA 11 images out.