### PR TITLE
FIX Switch to conda install from URL

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -36,9 +36,7 @@ source activate base
 env
 
 # Install gpuCI tools
-curl -s https://raw.githubusercontent.com/rapidsai/gpuci-tools/master/install.sh | bash
-source ~/.bashrc
-cd ~
+conda install -y -c gpuci gpuci-tools
 
 # Print diagnostic information
 gpuci_logger "Print conda info..."


### PR DESCRIPTION
Use the conda pkg install method so we're not dependent on the URL