### PR TITLE
Require Dask + Distributed 2.18.0

### DIFF
--- a/conda/recipes/release-versions.yaml
+++ b/conda/recipes/release-versions.yaml
@@ -42,11 +42,11 @@ cupy_version:
 cython_version:
   - '>=0.29,<0.30'
 dask_version:
-  - '>=2.15.0'
+  - '>=2.18.0'
 datashader_version:
   - '>=0.10.*'
 distributed_version:
-  - '>=2.15.0'
+  - '>=2.18.0'
 dlpack_version:
   - '=0.2'
 double_conversion_version:


### PR DESCRIPTION
This is needed to get the serialization fix in PR ( https://github.com/dask/distributed/pull/3639 ) included in Distributed 2.18.0.

xref: https://github.com/rapidsai/dask-cuda/pull/309

cc @dillon-cullinan