### PR TITLE
bumped up bokeh to >=2.1.1, panel>0.9.6, added pydeck

### DIFF
--- a/conda/recipes/nightly-versions.yaml
+++ b/conda/recipes/nightly-versions.yaml
@@ -28,7 +28,7 @@ arrow_version:
 blas_version:
   - '=2.14=openblas'
 bokeh_version:
-  - '=1.*'
+  - '>=2.1.1'
 boost_cpp_version:
   - '=1.72.0'
 clang_version:
@@ -82,7 +82,9 @@ pandas_version:
 pandoc_version:
   - '<=2.0.0'
 panel_version:
-  - '=0.6.*'
+  - '>=0.9.*'
+pydeck_version:
+  - '>=0.3'
 protobuf_version:
   - '>=3.4.1,<4.0.0'
 pyproj_version:

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -99,6 +99,7 @@ requirements:
     - protobuf {{ protobuf_version }}
     - psutil
     - pyarrow {{ arrow_version }}
+    - pydeck {{ pydeck_version }}
     - pynvml
     - pyppeteer
     - pyproj {{ pyproj_version }}

--- a/conda/recipes/release-versions.yaml
+++ b/conda/recipes/release-versions.yaml
@@ -85,6 +85,8 @@ panel_version:
   - '=0.6.*'
 protobuf_version:
   - '>=3.4.1,<4.0.0'
+pydeck_version:
+  - '>=0.3'
 pyproj_version:
   - '>=2.4.*'
 rapidjson_version:


### PR DESCRIPTION
- Updating the dependencies for cuxfilter. 
- Set bokeh minimum to 2.1.1 to support new features. jupyterlab-nvdashboard project also enforces this now to add bokeh>2 support.