### PR TITLE
ENH Add integration test script and YAML axis

### DIFF
--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -1,5 +1,8 @@
-DOCKER_REPO:
+RUNTIME_DOCKER_REPO:
   - rapidsai/rapidsai-nightly
+
+DOCKER_REPO:
+  - rapidsai/rapidsai-dev-nightly
 
 RAPIDS_VER:
   - 0.15

--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -1,0 +1,17 @@
+DOKCER_REPO:
+  - rapidsai/rapidsai-nightly
+
+RAPIDS_VER:
+  - 0.15
+
+CUDA_VER:
+  - 10.2
+  - 10.1
+
+LINUX_VER:
+  - ubuntu16.04
+  - ubuntu18.04
+  - centos7
+
+PYTHON_VER:
+  - 3.7

--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -1,4 +1,4 @@
-DOKCER_REPO:
+DOCKER_REPO:
   - rapidsai/rapidsai-nightly
 
 RAPIDS_VER:

--- a/ci/test/cudf.sh
+++ b/ci/test/cudf.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set +e
+set -x
+
+# mwendt: missing critical redirect
+export HOME=$WORKSPACE
+export LIBCUDF_KERNEL_CACHE_PATH=$WORKSPACE/.cache/rapids/cudf
+
+# FIXME: "source activate" line should not be needed
+source /opt/conda/bin/activate rapids
+#conda env update --quiet --name=rapids --file=/rapids/cudf/conda/environments/cudf_dev_cuda${CUDA_VERSION}.yml
+# mwendt: add cupy install to match gpuci scripts
+conda install -y -q -c conda-forge fastavro "rapidsai::cupy>=6.6.0,<8.0.0a0,!=7.1.0"
+# FIXME: Install the master version of dask, distributed, and streamz
+pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
+pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
+pip install "git+https://github.com/python-streamz/streamz.git" --upgrade --no-deps
+env
+conda list
+
+TESTRESULTS_DIR=${WORKSPACE}/testresults
+mkdir -p ${TESTRESULTS_DIR}
+SUITEERROR=0
+
+# build gtests
+pushd /rapids/cudf/cpp/build
+make build_tests_nvstrings
+SUITEERROR=$((SUITEERROR | $?))
+make build_tests_cudf
+SUITEERROR=$((SUITEERROR | $?))
+popd
+
+# run gtests
+for gt in /rapids/cudf/cpp/build/gtests/*; do
+   ${gt} --gtest_output=xml:${TESTRESULTS_DIR}/
+   exitcode=$?
+   if (( ${exitcode} != 0 )); then
+      SUITEERROR=${exitcode}
+      echo "FAILED: ${gt}"
+   fi
+done
+
+# Python tests
+export PYTHONPATH=\
+/rapids/cudf/python/cudf:\
+/rapids/cudf/python/dask_cudf:\
+/rapids/cudf/python/custreamz:\
+/rapids/cudf/python/nvstrings:\
+${PYTHONPATH}
+py.test --junitxml=${TESTRESULTS_DIR}/pytest-cudf.xml -v /rapids/cudf/python/cudf/cudf/tests /rapids/cudf/python/dask_cudf/dask_cudf/tests
+exitcode=$?
+if (( ${exitcode} != 0 )); then
+   SUITEERROR=${exitcode}
+   echo "FAILED: 1 or more python tests"
+fi
+
+# FIXME: nvstrings tests should not need to depend on a speacific CWD
+cd /rapids/cudf/python/nvstrings
+# mwendt: need to output this to different file from above otherwise it clobbers the results
+# mwendt: also removed specifying the `tests` directory to match gpuci scripts
+py.test --junitxml=${TESTRESULTS_DIR}/pytest-nvstrings.xml -v
+exitcode=$?
+if (( ${exitcode} != 0 )); then
+   SUITEERROR=${exitcode}
+   echo "FAILED: 1 or more python tests"
+fi
+
+# mwendt: adding custreamz tests
+cd /rapids/cudf/python/custreamz
+py.test --junitxml=${TESTRESULTS_DIR}/pytest-custreamz.xml -v
+exitcode=$?
+if (( ${exitcode} != 0 )); then
+   SUITEERROR=${exitcode}
+   echo "FAILED: 1 or more python tests"
+fi
+
+exit ${SUITEERROR}

--- a/ci/test/cugraph.sh
+++ b/ci/test/cugraph.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set +e
+set -x
+export HOME=$WORKSPACE
+export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
+
+# FIXME: "source activate" line should not be needed
+source /opt/conda/bin/activate rapids
+
+# Get datasets
+cd /rapids/cugraph/datasets
+bash ./get_test_data.sh
+export RAPIDS_DATASET_ROOT_DIR=/rapids/cugraph/datasets
+
+# Install test deps
+conda install -y -c conda-forge -c defaults python-louvain networkx
+# FIXME: Install the master version of dask, distributed, and streamz
+pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
+pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
+env
+conda list
+
+TESTRESULTS_DIR=${WORKSPACE}/testresults
+mkdir -p ${TESTRESULTS_DIR}
+SUITEERROR=0
+
+# gtests
+for gt in /rapids/cugraph/cpp/build/gtests/*_TEST; do
+   # FIXME: remove this ASAP
+   if [[ ${gt} == "/rapids/cugraph/cpp/build/gtests/SNMG_SPMV_TEST" ]]; then
+      ${gt} --gtest_output=xml:${TESTRESULTS_DIR}/ --gtest_filter=-hibench_test/Tests_MGSpmv_hibench.CheckFP32_hibench*
+      exitcode=$?
+   else
+      ${gt} --gtest_output=xml:${TESTRESULTS_DIR}/
+      exitcode=$?
+   fi
+   if (( ${exitcode} != 0 )); then
+      SUITEERROR=${exitcode}
+      echo "FAILED: ${gt}"
+   fi
+done
+
+# Python tests
+py.test --junitxml=${TESTRESULTS_DIR}/pytest.xml -v /rapids/cugraph/python
+exitcode=$?
+if (( ${exitcode} != 0 )); then
+   SUITEERROR=${exitcode}
+   echo "FAILED: 1 or more tests in /rapids/cugraph/python"
+fi
+
+exit ${SUITEERROR}

--- a/ci/test/cuml.sh
+++ b/ci/test/cuml.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set +e
+
+export HOME=$WORKSPACE
+export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
+
+# FIXME: "source activate" line should not be needed
+source /opt/conda/bin/activate rapids
+#conda env update --quiet --name=rapids --file=/rapids/cuml/conda/environments/cuml_dev_cuda${CUDA_VERSION}.yml
+conda install -y -c conda-forge scikit-learn>=0.21 umap-learn>=0.3.9 lightgbm
+# FIXME: Install the master version of dask, distributed, and streamz
+pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
+pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
+pip install "git+https://github.com/python-streamz/streamz.git" --upgrade --no-deps
+env
+conda list
+
+TESTRESULTS_DIR=${WORKSPACE}/testresults
+mkdir -p ${TESTRESULTS_DIR}
+SUITEERROR=0
+
+export CUPY_CACHE_DIR=${WORKSPACE}/tmp
+mkdir -p ${CUPY_CACHE_DIR}
+
+# gtests
+# FIXME: add /rapids/cuml/cpp/build/test/ml_mg when multi-gpus are available!
+for gt in \
+      /rapids/cuml/cpp/build/test/ml \
+      /rapids/cuml/cpp/build/test/prims ; do
+   ${gt} --gtest_output=xml:${TESTRESULTS_DIR}/
+   exitcode=$?
+   if (( ${exitcode} != 0 )); then
+      SUITEERROR=${exitcode}
+      echo "FAILED: ${gt}"
+   fi
+done
+
+# Python tests
+py.test --junitxml=${TESTRESULTS_DIR}/pytest.xml -v /rapids/cuml/python/cuml/test -m "not memleak"
+exitcode=$?
+if (( ${exitcode} != 0 )); then
+   SUITEERROR=${exitcode}
+   echo "FAILED: 1 or more python tests"
+fi
+
+exit ${SUITEERROR}

--- a/ci/test/cuspatial.sh
+++ b/ci/test/cuspatial.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -ex
+
+export CUSPATIAL_HOME=/rapids/cuspatial
+export HOME=$WORKSPACE
+
+# FIXME: "source activate" line should not be needed
+source /opt/conda/bin/activate rapids
+env
+conda list
+
+TESTRESULTS_DIR=${WORKSPACE}/testresults
+mkdir -p ${TESTRESULTS_DIR}
+SUITEERROR=0
+
+# Python tests
+cd /rapids/cuspatial
+py.test --junitxml=${TESTRESULTS_DIR}/pytest.xml -v python/cuspatial/cuspatial/tests
+exitcode=$?
+if (( ${exitcode} != 0 )); then
+   SUITEERROR=${exitcode}
+   echo "FAILED: 1 or more python tests"
+fi
+
+exit ${SUITEERROR}

--- a/ci/test/daskcuda.sh
+++ b/ci/test/daskcuda.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set +e
+set -x
+# FIXME: "source activate" line should not be needed
+source /opt/conda/bin/activate rapids
+# FIXME: should this be in the container?
+# mwendt: this needs to be installed from `rapidsai` to keep the correct NCCL version already in the container
+#         cupy right now is only needed for testing so that is why cudf/daskcuda install it separately in their ci/gpu/build.sh
+conda install -y rapidsai::cupy
+env
+conda list
+
+# mwendt: crucial redirect missing https://github.com/rapidsai/dask-cuda/blob/39eac0235a84dfd36ac0170e60a4cb3fdde17f47/ci/gpu/build.sh#L21
+export HOME=$WORKSPACE 
+
+TESTRESULTS_DIR=${WORKSPACE}/testresults
+mkdir -p ${TESTRESULTS_DIR}
+SUITEERROR=0
+
+# Install distributed@master (temporarily required due to issues with 2.3.2)
+pip install git+https://github.com/dask/distributed.git@master
+pip install pytest-asyncio fsspec
+
+# Python tests
+cd /rapids/dask-cuda/dask_cuda
+py.test --junitxml=${TESTRESULTS_DIR}/pytest.xml -v 
+exitcode=$?
+if (( ${exitcode} != 0 )); then
+   SUITEERROR=${exitcode}
+   echo "FAILED: 1 or more tests in /rapids/dask-cuda/dask_cuda/tests"
+fi
+
+exit ${SUITEERROR}

--- a/ci/test/integration.sh
+++ b/ci/test/integration.sh
@@ -30,3 +30,5 @@ if (( ${exitcode} != 0 )); then
    SUITEERROR=${exitcode}
    gpuci_logger "FAILED: 1 or more tests in /rapids/integration/test"
 fi
+
+exit ${SUITEERROR}

--- a/ci/test/integration.sh
+++ b/ci/test/integration.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -ex
+. /opt/conda/etc/profile.d/conda.sh
+conda activate rapids
+
+export HOME=${WORKSPACE}
+export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
+export PATH="$PATH:/opt/conda/bin"
+
+gpuci_logger "Show env and current conda list"
+env
+conda list
+
+export TESTRESULTS_DIR=${WORKSPACE}/testresults
+mkdir -p ${TESTRESULTS_DIR}
+SUITEERROR=0
+
+gpuci_logger "Install conda packages needed by tests in rapids environment"
+gpuci_conda_retry --condaretry_max_retries=10 install -y --freeze-installed requests
+
+gpuci_logger "Install integration tests"
+ls -la /
+cd /rapids
+git clone https://github.com/rapidsai/integration
+
+gpuci_logger "Run Python tests"
+py.test --junitxml=${TESTRESULTS_DIR}/pytest.xml -v /rapids/integration/test
+exitcode=$?
+if (( ${exitcode} != 0 )); then
+   SUITEERROR=${exitcode}
+   gpuci_logger "FAILED: 1 or more tests in /rapids/integration/test"
+fi

--- a/ci/test/notebooks.sh
+++ b/ci/test/notebooks.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set +e
+set -x
+set -o pipefail
+
+export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
+
+source /opt/conda/bin/activate rapids
+env
+/test.sh 2>&1 | tee nbtest.log
+EXITCODE=$?
+python /rapids/utils/nbtestlog2junitxml.py nbtest.log
+
+exit ${EXITCODE}

--- a/ci/test/rmm.sh
+++ b/ci/test/rmm.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -ex
+export HOME=$WORKSPACE
+# FIXME: "source activate" line should not be needed
+source /opt/conda/bin/activate rapids
+env
+conda list
+
+TESTRESULTS_DIR=${WORKSPACE}/testresults
+mkdir -p ${TESTRESULTS_DIR}
+SUITEERROR=0
+
+# gtests
+for gt in /rapids/rmm/build/gtests/*; do
+   ${gt} --gtest_output=xml:${TESTRESULTS_DIR}/
+   exitcode=$?
+   if (( ${exitcode} != 0 )); then
+      SUITEERROR=${exitcode}
+      echo "FAILED: ${gt}"
+   fi
+done
+
+# Python tests
+cd /rapids/rmm/python
+py.test --cache-clear --junitxml=${TESTRESULTS_DIR}/rmm_pytest.xml -v
+exitcode=$?
+if (( ${exitcode} != 0 )); then
+   SUITEERROR=${exitcode}
+   echo "FAILED: 1 or more tests in /rapids/rmm/python/tests"
+fi
+
+exit ${SUITEERROR}


### PR DESCRIPTION
## Overview
This PR works to move all of the config and scripts for all integration/nightly tests out of Jenkins and into the repo. In addition, using the `tests.yaml` axis config file will make updates to all tests easier as they all share a common YAML config file.

In this PR the scripts are not cleaned-up or consolidated; that will be done in a future PR.

In addition, this PR will remove CUDA 10.0 and Python 3.6 from the testing options in prep for dropping those combinations across RAPIDS for v0.15 release.

## Approach
- [x] Reconfigured existing jobs to use YAML and this repo/branch - https://gpuci.gpuopenanalytics.com/job/rapidsai/job/nightly-tests/
- [x] Updated runtime tests pipeline - see [diff](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/docker/job/rapidsai-base-runtime-nightly-test-pipeline/jobConfigHistory/showDiffFiles?timestamp1=2020-07-07_09-09-28&timestamp2=2020-07-08_09-55-52)
- [x] Updated devel tests pipeline - see [diff](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/docker/job/rapidsai-devel-nightly-test-pipeline/jobConfigHistory/showDiffFiles?timestamp1=2020-07-07_09-09-58&timestamp2=2020-07-08_09-58-46)

## Post-merge steps
- Update the jobs here to use the main branch of this repo instead - https://gpuci.gpuopenanalytics.com/job/rapidsai/job/nightly-tests/