### PR TITLE
ENH Drop CUDA 10.0 and Python 3.6

### DIFF
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -11,11 +11,9 @@ RAPIDS_VER:
 CUDA_VER:
   - 10.2
   - 10.1
-  - 10.0
 
 DEFAULT_CUDA_VER:
   - 10.1
 
 PYTHON_VER:
-  - 3.6
   - 3.7

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -11,11 +11,9 @@ RAPIDS_VER:
 CUDA_VER:
   - 10.2
   - 10.1
-  - 10.0
 
 DEFAULT_CUDA_VER:
   - 10.1
 
 PYTHON_VER:
-  - 3.6
   - 3.7


### PR DESCRIPTION
Dropping CUDA 10.0 to support 10.1, 10.2 and in the future 11.0. Dropping Python 3.6 due to community guidelines that have removed support for 3.6 at the end of June. To match their support model, this PR also drops support for 3.6 in prep for 3.8 coming in a future update.

As a part of this update, we're switching to CUDA 10.1 as the "default" CUDA version for RAPIDS. This was already updated and didn't need to be changed.