### PR TITLE
Require `pickle5` (on older Python versions)

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -95,6 +95,7 @@ requirements:
     - numpy {{ numpy_version }}
     - pandas {{ pandas_version }}
     - panel {{ panel_version }}
+    - pickle5  # [py<38]
     - pkg-config
     - protobuf {{ protobuf_version }}
     - psutil

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - nccl {{ nccl_version }}
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}
+    - pickle5  # [py<38]
     - python
     - cudf ={{ minor_version }}.*
     - cugraph ={{ minor_version }}.*


### PR DESCRIPTION
For older versions of Python, make sure the `pickle5` backport package is available. This way we can still leverage the features of pickle protocol 5 (namely out-of-band buffer serialization) on older Python versions.

https://docs.python.org/3/library/pickle.html#pickle-oob
https://www.python.org/dev/peps/pep-0574/
https://github.com/pitrou/pickle5-backport