### PR TITLE
Remove jq from rapids-doc-env

### DIFF
--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -38,7 +38,6 @@ requirements:
     - beautifulsoup4
     - doxygen
     - markdown
-    - jq
     - nbsphinx
     - numpydoc
     - pandoc {{ pandoc_version }}


### PR DESCRIPTION
PR https://github.com/rapidsai/gpuci-build-environment/pull/106 added `jq` to the `devel` images of `gpuci`. Since the only `rapidsai` image to use the `rapids-doc-env` package is rapidsai/devel images, we should be able to now remove `jq` from `rapids-doc-env`.
