### PR TITLE
[REVIEW] Pinning black, flake8 and isort

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - async_generator
     - autoconf
     - automake
-    - black
+    - black ={{ black_version }}
     - conda-forge::blas{{ blas_version }}
     - boost
     - boost-cpp {{ boost_cpp_version }}
@@ -64,7 +64,7 @@ requirements:
     - double-conversion {{ double_conversion_version }}
     - fastavro {{ fastavro_version }}
     - feather-format
-    - flake8
+    - flake8 ={{ flake8_version }}
     - flatbuffers {{ flatbuffers_version }}
     - fsspec {{ fsspec_version }}
     - gcsfs
@@ -74,7 +74,7 @@ requirements:
     - graphviz
     - httpretty
     - hypothesis
-    - isort
+    - isort ={{ isort_version }}
     - lapack
     - libcumlprims ={{ minor_version }}.*
     - libcypher-parser

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - async_generator
     - autoconf
     - automake
-    - black ={{ black_version }}
+    - black {{ black_version }}
     - conda-forge::blas{{ blas_version }}
     - boost
     - boost-cpp {{ boost_cpp_version }}
@@ -64,7 +64,7 @@ requirements:
     - double-conversion {{ double_conversion_version }}
     - fastavro {{ fastavro_version }}
     - feather-format
-    - flake8 ={{ flake8_version }}
+    - flake8 {{ flake8_version }}
     - flatbuffers {{ flatbuffers_version }}
     - fsspec {{ fsspec_version }}
     - gcsfs
@@ -74,7 +74,7 @@ requirements:
     - graphviz
     - httpretty
     - hypothesis
-    - isort ={{ isort_version }}
+    - isort {{ isort_version }}
     - lapack
     - libcumlprims ={{ minor_version }}.*
     - libcypher-parser

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -25,6 +25,8 @@ build_stack_version:
 # Shared versions across meta-pkgs
 arrow_version:
   - '=0.17.1'
+black_version:
+  - '=19.10b0'
 blas_version:
   - '=2.14=openblas'
 bokeh_version:
@@ -53,6 +55,8 @@ double_conversion_version:
   - '=3.1.5'
 fastavro_version:
   - '>=0.22.0'
+flake8_version:
+  - '=3.8.3'
 flatbuffers_version:
   - '=1.10.0'
 fsspec_version:
@@ -63,6 +67,8 @@ geopandas_version:
   - '>=0.6.*'
 ipython_version:
   - '=7.3.*'
+isort_version:
+  - '=5.0.7'
 jupyterlab_version:
   - '=2.1.*'
 librdkafka_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -26,7 +26,7 @@ build_stack_version:
 arrow_version:
   - '=0.17.1'
 black_version:
-  - '=19.10b0'
+  - '=19.10'
 blas_version:
   - '=2.14=openblas'
 bokeh_version:
@@ -56,7 +56,7 @@ double_conversion_version:
 fastavro_version:
   - '>=0.22.0'
 flake8_version:
-  - '=3.8.3'
+  - '=3.8.*'
 flatbuffers_version:
   - '=1.10.0'
 fsspec_version:
@@ -68,7 +68,7 @@ geopandas_version:
 ipython_version:
   - '=7.15.*'
 isort_version:
-  - '=5.0.7'
+  - '=5.0.*'
 jupyterlab_version:
   - '=2.1.*'
 librdkafka_version:


### PR DESCRIPTION
black, flake8 and isort are not controlled by their versions. And sometimes these break and block CIs. So planning to control the version of these to ensure smooth CI operation.

It is open for review, but as this will affect all the RAPIDS projects, wanted to check with PICs of those projects if they have any concerns or any other approach to handle this issue.

