### PR TITLE
ENH Add CUDA 11.0

### DIFF
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -9,8 +9,7 @@ RAPIDS_VER:
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
-  - 10.2
-  - 10.1
+  - 11.0
 
 DEFAULT_CUDA_VER:
   - 10.1

--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -10,9 +10,12 @@ RAPIDS_VER:
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
   - 11.0
+  - 10.2
+  - 10.1
 
 DEFAULT_CUDA_VER:
   - 10.1
 
 PYTHON_VER:
   - 3.7
+  - 3.8

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -9,8 +9,7 @@ RAPIDS_VER:
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
-  - 10.2
-  - 10.1
+  - 11.0
 
 DEFAULT_CUDA_VER:
   - 10.1

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -10,9 +10,13 @@ RAPIDS_VER:
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
   - 11.0
+  - 10.2
+  - 10.1
 
 DEFAULT_CUDA_VER:
   - 10.1
 
 PYTHON_VER:
   - 3.7
+  - 3.8
+  

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -50,6 +50,13 @@ if [[ "$BUILD_MODE" = "branch" && "$SOURCE_BRANCH" = branch-* ]] ; then
 fi
 
 function build_pkg {
+  # Create 'conda_build_config.yaml' with CUDA version
+  gpuci_logger "Creating ''..."
+  cat > ${1}/conda_build_config.yaml <<EOF
+cuda_compiler_version:
+- '$CUDA_VER'
+EOF
+  cat ${1}/conda_build_config.yaml
   # Build pkg
   gpuci_logger "Start conda build for '${1}'..."
   conda build --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge -c defaults \

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -51,7 +51,7 @@ fi
 
 function build_pkg {
   # Create 'conda_build_config.yaml' with CUDA version
-  gpuci_logger "Creating ''..."
+  gpuci_logger "Creating 'conda_build_config.yaml' with CUDA_VER='$CUDA_VER' to select correct pkgs..."
   cat > ${1}/conda_build_config.yaml <<EOF
 cuda_compiler_version:
 - '$CUDA_VER'

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -76,7 +76,7 @@ requirements:
     - hypothesis
     - isort
     - lapack
-    - libcumlprims ={{ minor_version }}.*
+    #- libcumlprims ={{ minor_version }}.*
     - libcypher-parser
     - libgcc-ng {{ build_stack_version }}
     - libgfortran-ng {{ build_stack_version }}
@@ -123,7 +123,7 @@ requirements:
     - streamz
     - treelite {{ treelite_version }}
     - twine
-    - ucx-py ={{ minor_version }}.*
+    #- ucx-py ={{ minor_version }}.*
     - umap-learn
 
 about:

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -54,7 +54,8 @@ requirements:
     - conda-build {{ conda_build_version }}
     - conda-verify {{ conda_verify_version }}
     - cudatoolkit ={{ cuda_version }}.*
-    - cupy {{ cupy_version }}
+    - cupy {{ cupy_version }} # [cuda_version<11.0]
+    - cupy {{ cuda11_cupy_version }} # [cuda_version=11.0]
     - cython {{ cython_version }}
     - dask {{ dask_version }}
     - dask-ml
@@ -89,7 +90,8 @@ requirements:
     - lightgbm
     - make
     - moto
-    - nccl {{ nccl_version }}
+    - nccl {{ nccl_version }} # [cuda_version<11.0]
+    - nccl {{ cuda11_nccl_version }} # [cuda_version=11.0]
     - networkx {{ networkx_version }}
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -55,8 +55,8 @@ requirements:
     - conda-build {{ conda_build_version }}
     - conda-verify {{ conda_verify_version }}
     - cudatoolkit ={{ cuda_version }}.*
-    - cupy {{ cupy_version }} # [cuda_version != "11.0"]
-    - cupy {{ cuda11_cupy_version }} # [cuda_version == "11.0"]
+    - cupy {{ cupy_version }} # [cuda_compiler_version != "11.0"]
+    - cupy {{ cuda11_cupy_version }} # [cuda_compiler_version == "11.0"]
     - cython {{ cython_version }}
     - dask {{ dask_version }}
     - dask-ml
@@ -95,8 +95,8 @@ requirements:
     - lightgbm
     - make
     - moto
-    - nccl {{ nccl_version }} # [cuda_version != "11.0"]
-    - nccl {{ cuda11_nccl_version }} # [cuda_version == "11.0"]
+    - nccl {{ nccl_version }} # [cuda_compiler_version != "11.0"]
+    - nccl {{ cuda11_nccl_version }} # [cuda_compiler_version == "11.0"]
     - networkx {{ networkx_version }}
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -55,8 +55,8 @@ requirements:
     - conda-build {{ conda_build_version }}
     - conda-verify {{ conda_verify_version }}
     - cudatoolkit ={{ cuda_version }}.*
-    - cupy {{ cupy_version }} # [cuda_version<11.0]
-    - cupy {{ cuda11_cupy_version }} # [cuda_version=11.0]
+    - cupy {{ cupy_version }} # [cuda_version != "11.0"]
+    - cupy {{ cuda11_cupy_version }} # [cuda_version == "11.0"]
     - cython {{ cython_version }}
     - dask {{ dask_version }}
     - dask-ml
@@ -95,8 +95,8 @@ requirements:
     - lightgbm
     - make
     - moto
-    - nccl {{ nccl_version }} # [cuda_version<11.0]
-    - nccl {{ cuda11_nccl_version }} # [cuda_version=11.0]
+    - nccl {{ nccl_version }} # [cuda_version != "11.0"]
+    - nccl {{ cuda11_nccl_version }} # [cuda_version == "11.0"]
     - networkx {{ networkx_version }}
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -76,7 +76,7 @@ requirements:
     - hypothesis
     - isort
     - lapack
-    #- libcumlprims ={{ minor_version }}.*
+    - libcumlprims ={{ minor_version }}.*
     - libcypher-parser
     - libgcc-ng {{ build_stack_version }}
     - libgfortran-ng {{ build_stack_version }}
@@ -123,7 +123,7 @@ requirements:
     - streamz
     - treelite {{ treelite_version }}
     - twine
-    #- ucx-py ={{ minor_version }}.*
+    - ucx-py ={{ minor_version }}.*
     - umap-learn
 
 about:

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -39,8 +39,8 @@ requirements:
     - bokeh {{ bokeh_version }}
     - conda-forge::blas{{ blas_version }}
     - cudatoolkit ={{ cuda_version }}.*
-    - cupy {{ cupy_version }} # [cuda_version<11.0]
-    - cupy {{ cuda11_cupy_version }} # [cuda_version=11.0]
+    - cupy {{ cupy_version }} # [cuda_version != "11.0"]
+    - cupy {{ cuda11_cupy_version }} # [cuda_version == "11.0"]
     - cython {{ cython_version }}
     - dask-labextension
     - dask-ml

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -39,8 +39,8 @@ requirements:
     - bokeh {{ bokeh_version }}
     - conda-forge::blas{{ blas_version }}
     - cudatoolkit ={{ cuda_version }}.*
-    - cupy {{ cupy_version }} # [cuda_version != "11.0"]
-    - cupy {{ cuda11_cupy_version }} # [cuda_version == "11.0"]
+    - cupy {{ cupy_version }} # [cuda_compiler_version != "11.0"]
+    - cupy {{ cuda11_cupy_version }} # [cuda_compiler_version == "11.0"]
     - cython {{ cython_version }}
     - dask-labextension
     - dask-ml

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -39,7 +39,8 @@ requirements:
     - bokeh {{ bokeh_version }}
     - conda-forge::blas{{ blas_version }}
     - cudatoolkit ={{ cuda_version }}.*
-    - cupy {{ cupy_version }}
+    - cupy {{ cupy_version }} # [cuda_version<11.0]
+    - cupy {{ cuda11_cupy_version }} # [cuda_version=11.0]
     - cython {{ cython_version }}
     - dask-labextension
     - dask-ml

--- a/conda/recipes/rapids-xgboost/meta.yaml
+++ b/conda/recipes/rapids-xgboost/meta.yaml
@@ -37,11 +37,11 @@ requirements:
     - python
   run:
     - cudatoolkit ={{ cuda_version }}.*
-    - nccl {{ nccl_version }} # [cuda_version != "11.0"]
-    - nccl {{ cuda11_nccl_version }} # [cuda_version == "11.0"]
+    - nccl {{ nccl_version }} # [cuda_compiler_version != "11.0"]
+    - nccl {{ cuda11_nccl_version }} # [cuda_compiler_version == "11.0"]
     - python
-    - xgboost {{ xgboost_version }} # [cuda_version != "11.0"]
-    - xgboost {{ cuda11_xgboost_version }} # [cuda_version == "11.0"]
+    - xgboost {{ xgboost_version }} # [cuda_compiler_version != "11.0"]
+    - xgboost {{ cuda11_xgboost_version }} # [cuda_compiler_version == "11.0"]
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/rapids-xgboost/meta.yaml
+++ b/conda/recipes/rapids-xgboost/meta.yaml
@@ -37,11 +37,11 @@ requirements:
     - python
   run:
     - cudatoolkit ={{ cuda_version }}.*
-    - nccl {{ nccl_version }} # [cuda_version<11.0]
-    - nccl {{ cuda11_nccl_version }} # [cuda_version=11.0]
+    - nccl {{ nccl_version }} # [cuda_version != "11.0"]
+    - nccl {{ cuda11_nccl_version }} # [cuda_version == "11.0"]
     - python
-    - xgboost {{ xgboost_version }} # [cuda_version<11.0]
-    - xgboost {{ cuda11_xgboost_version }} # [cuda_version=11.0]
+    - xgboost {{ xgboost_version }} # [cuda_version != "11.0"]
+    - xgboost {{ cuda11_xgboost_version }} # [cuda_version == "11.0"]
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/rapids-xgboost/meta.yaml
+++ b/conda/recipes/rapids-xgboost/meta.yaml
@@ -37,9 +37,11 @@ requirements:
     - python
   run:
     - cudatoolkit ={{ cuda_version }}.*
-    - nccl {{ nccl_version }}
+    - nccl {{ nccl_version }} # [cuda_version<11.0]
+    - nccl {{ cuda11_nccl_version }} # [cuda_version=11.0]
     - python
-    - xgboost {{ xgboost_version }}
+    - xgboost {{ xgboost_version }} # [cuda_version<11.0]
+    - xgboost {{ cuda11_xgboost_version }} # [cuda_version=11.0]
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -37,10 +37,10 @@ requirements:
     - python
   run:
     - cudatoolkit ={{ cuda_version }}.*
-    - cupy {{ cupy_version }} # [cuda_version<11.0]
-    - cupy {{ cuda11_cupy_version }} # [cuda_version=11.0]
-    - nccl {{ nccl_version }} # [cuda_version<11.0]
-    - nccl {{ cuda11_nccl_version }} # [cuda_version=11.0]
+    - cupy {{ cupy_version }} # [cuda_version != "11.0"]
+    - cupy {{ cuda11_cupy_version }} # [cuda_version == "11.0"]
+    - nccl {{ nccl_version }} # [cuda_version != "11.0"]
+    - nccl {{ cuda11_nccl_version }} # [cuda_version == "11.0"]
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}
     - pickle5  # [py<38]

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -37,10 +37,10 @@ requirements:
     - python
   run:
     - cudatoolkit ={{ cuda_version }}.*
-    - cupy {{ cupy_version }} # [cuda_version != "11.0"]
-    - cupy {{ cuda11_cupy_version }} # [cuda_version == "11.0"]
-    - nccl {{ nccl_version }} # [cuda_version != "11.0"]
-    - nccl {{ cuda11_nccl_version }} # [cuda_version == "11.0"]
+    - cupy {{ cupy_version }} # [cuda_compiler_version != "11.0"]
+    - cupy {{ cuda11_cupy_version }} # [cuda_compiler_version == "11.0"]
+    - nccl {{ nccl_version }} # [cuda_compiler_version != "11.0"]
+    - nccl {{ cuda11_nccl_version }} # [cuda_compiler_version == "11.0"]
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}
     - pickle5  # [py<38]

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -37,8 +37,10 @@ requirements:
     - python
   run:
     - cudatoolkit ={{ cuda_version }}.*
-    - cupy {{ cupy_version }}
-    - nccl {{ nccl_version }}
+    - cupy {{ cupy_version }} # [cuda_version<11.0]
+    - cupy {{ cuda11_cupy_version }} # [cuda_version=11.0]
+    - nccl {{ nccl_version }} # [cuda_version<11.0]
+    - nccl {{ cuda11_nccl_version }} # [cuda_version=11.0]
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}
     - pickle5  # [py<38]

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -38,7 +38,7 @@ cmake_version:
 cmake_setuptools_version:
   - '>=0.1.3'
 cupy_version:
-  - '>=7,<8.0.0a0,!=7.1.0'
+  - '>=7.1.0,<8.0.0dev1'
 cython_version:
   - '>=0.29,<0.30'
 dask_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -8,7 +8,7 @@ dask_xgboost_version:
 
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
-  - '>=1.1.0dev.rapidsai0.15'
+  - '=1.1.0dev.rapidsai0.15'
 
 # Versions for conda
 conda_version:
@@ -38,7 +38,7 @@ cmake_version:
 cmake_setuptools_version:
   - '>=0.1.3'
 cupy_version:
-  - '>=7.1.0'
+  - '>=7.1.0,<8.0.0a0'
 cython_version:
   - '>=0.29,<0.30'
 dask_version:
@@ -68,7 +68,7 @@ jupyterlab_version:
 librdkafka_version:
   - '=1.4.2'
 nccl_version:
-  - '>=2.5'
+  - '=2.5'
 networkx_version:
   - '>=2.3'
 nodejs_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -68,7 +68,7 @@ jupyterlab_version:
 librdkafka_version:
   - '=1.4.2'
 nccl_version:
-  - '=2.5.*'
+  - '>=2.5'
 networkx_version:
   - '>=2.3'
 nodejs_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -38,7 +38,7 @@ cmake_version:
 cmake_setuptools_version:
   - '>=0.1.3'
 cupy_version:
-  - '>=7.1.0,<8.0.0dev1'
+  - '>=7.1.0'
 cython_version:
   - '>=0.29,<0.30'
 dask_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -26,7 +26,7 @@ build_stack_version:
 cuda11_cupy_version:
   - '=8.0.0dev0'
 cuda11_nccl_version:
-  - '>=2.5'
+  - '>=2.7.6.1,<3.0a0'
 cuda11_xgboost_version:
   - '=1.2.0dev.rapidsai0.15'
 

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -8,7 +8,7 @@ dask_xgboost_version:
 
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
-  - '=1.1.0dev.rapidsai0.15'
+  - '>=1.1.0dev.rapidsai0.15'
 
 # Versions for conda
 conda_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -44,7 +44,7 @@ cython_version:
 dask_version:
   - '>=2.15.0'
 datashader_version:
-  - '>=0.10.*'
+  - '>=0.10'
 distributed_version:
   - '>=2.15.0'
 dlpack_version:
@@ -60,11 +60,11 @@ fsspec_version:
 gdal_version:
   - '>=3.0.2,<3.1.0a0'
 geopandas_version:
-  - '>=0.6.*'
+  - '>=0.6'
 ipython_version:
-  - '=7.3.*'
+  - '=7.3'
 jupyterlab_version:
-  - '=2.1.*'
+  - '=2.1'
 librdkafka_version:
   - '=1.4.2'
 nccl_version:
@@ -82,13 +82,13 @@ pandas_version:
 pandoc_version:
   - '<=2.0.0'
 panel_version:
-  - '>=0.9.*'
+  - '>=0.9'
 pydeck_version:
   - '>=0.3'
 protobuf_version:
   - '>=3.4.1,<4.0.0'
 pyproj_version:
-  - '>=2.4.*'
+  - '>=2.4'
 rapidjson_version:
   - '=1.1.0'
 scikit_learn_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -22,6 +22,14 @@ conda_verify_version:
 build_stack_version:
   - '=7.5.0'
 
+# Overrides for CUDA 11 specific versions
+cuda11_cupy_version:
+  - '=8.0.0dev0'
+cuda11_nccl_version:
+  - '>=2.5'
+cuda11_xgboost_version:
+  - '=1.2.0dev.rapidsai0.15'
+
 # Shared versions across meta-pkgs
 arrow_version:
   - '=0.17.1'


### PR DESCRIPTION
For now only test and build 11.0 to find all missing packages needed to support. Update versions as needed to support CUDA CTK requirements and the updated `cuDNN` and `nvcc` as well as `cuPy`.