### PR TITLE
[skip ci] Update master references for main branch

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -28,7 +28,7 @@ source activate gdf
 env
 
 # Install gpuCI tools
-curl -s https://raw.githubusercontent.com/rapidsai/gpuci-tools/master/install.sh | bash
+curl -s https://raw.githubusercontent.com/rapidsai/gpuci-tools/main/install.sh | bash
 source ~/.bashrc
 cd ~
 


### PR DESCRIPTION
This PR changes any 'master' references to 'main' in markdown files throughout the repo as part of the new 'master' to 'main' branch migration.