### PR TITLE
Updated ci/axis nightly.yaml and release.yaml to reflect python 3.8. …

### DIFF
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -17,3 +17,4 @@ DEFAULT_CUDA_VER:
 
 PYTHON_VER:
   - 3.7
+  - 3.8

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -17,3 +17,4 @@ DEFAULT_CUDA_VER:
 
 PYTHON_VER:
   - 3.7
+  - 3.8

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -62,7 +62,7 @@ gdal_version:
 geopandas_version:
   - '>=0.6.*'
 ipython_version:
-  - '=7.3.*'
+  - '=7.15.*'
 jupyterlab_version:
   - '=2.1.*'
 librdkafka_version:
@@ -92,10 +92,12 @@ pyproj_version:
 rapidjson_version:
   - '=1.1.0'
 scikit_learn_version:
-  - '=0.23.0'
+  - '=0.23.1'
 scipy_version:
-  - '=1.3.0'
+  - '=1.4.1'
 spdlog_version:
   - '=1.6.0'
+sphinx_markdown_tables_version:
+  - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
   - '=0.92'


### PR DESCRIPTION
Updated ci/axis nightly.yaml and release.yaml to reflect addition of python 3.8.  
Updated conda/recipes/versions.yaml to add package updates for the following:

ipython_version:
  - '=7.15.*'
scikit_learn_version:
  - '=0.23.1'
scipy_version:
  - '=1.4.1'
sphinx_markdown_tables:
  - '=0.0.14=pyh9f0ad1d_1'