### PR TITLE
[Review] Update scipy to 1.5.1 for cuSignal CI

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -94,7 +94,7 @@ rapidjson_version:
 scikit_learn_version:
   - '=0.23.1'
 scipy_version:
-  - '=1.4.1'
+  - '=1.5.1'
 spdlog_version:
   - '=1.6.0'
 sphinx_markdown_tables_version:


### PR DESCRIPTION
This PR updates the scipy version in `versions.yaml` to 1.5.1 from 1.4.1.

This is required for cuSignal CI process.