### PR TITLE
[PR-REVIEW] Update version to cap numpy at 1.18.5

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -76,7 +76,7 @@ nodejs_version:
 numba_version:
   - '>=0.49'
 numpy_version:
-  - '>=1.17.3'
+  - '>=1.17.3,<1.19'
 pandas_version:
   - '>=1.0,<1.1.0a0'
 pandoc_version:


### PR DESCRIPTION
This PR caps NumPy version to 1.18.5 to alleviate issues seen in cuSignals pytest runs.

I've did a scan of cuML, cuDF, cuGRAPH, and cuSpatial and did not see NumPy in their `build` requirements.