### PR TITLE
[REVIEW] Add custreamz to rapids

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -48,6 +48,7 @@ requirements:
     - cuml ={{ minor_version }}.*
     - cusignal ={{ minor_version }}.*
     - cuspatial ={{ minor_version }}.*
+    - custreamz ={{ minor_version }}.*
     - cuxfilter ={{ minor_version }}.*
     - dask-cuda ={{ minor_version }}.*
     - dask-xgboost {{ dask_xgboost_version }}


### PR DESCRIPTION
Adding the custreamz meta-package to the rapids meta-package. custreamz is available in the devel containers since it installs the streamz dependency via `rapids-build-env`, but unavailable in base/runtime since they use `rapids` instead of `rapids-build-env`.