### PR TITLE
Added python-confluent-kafka dependency to conda build-env recipe

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -110,6 +110,7 @@ requirements:
     - pytest-cov
     - pytest-timeout
     - python
+    - python-confluent-kafka {{ python_confluent_kafka_version }}
     - python-louvain
     - rapidjson {{ rapidjson_version }}
     - ripgrep

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -48,6 +48,7 @@ requirements:
     - cuml ={{ minor_version }}.*
     - cusignal ={{ minor_version }}.*
     - cuspatial ={{ minor_version }}.*
+    - custreamz ={{ minor_version }}.*
     - cuxfilter ={{ minor_version }}.*
     - dask-cuda ={{ minor_version }}.*
     - dask-xgboost {{ dask_xgboost_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -91,6 +91,8 @@ panel_version:
   - '>=0.9.*'
 pydeck_version:
   - '>=0.3'
+python_confluent_kafka_version:
+  - '=1.3.0'
 protobuf_version:
   - '>=3.4.1,<4.0.0'
 pyproj_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -92,7 +92,7 @@ panel_version:
 pydeck_version:
   - '>=0.3'
 python_confluent_kafka_version:
-  - '=1.3.0'
+  - '>=1.3.0'
 protobuf_version:
   - '>=3.4.1,<4.0.0'
 pyproj_version:


### PR DESCRIPTION
Added `python-confluent-kafka` to conda recipe and also added `custreamz` to the rapids recipe since that is also needed now.

This closes #85 