### PR TITLE
Relax `blas` to allow other BLAS implementations

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - automake
     - benchmark {{ benchmark_version }}
     - black {{ black_version }}
-    - conda-forge::blas{{ blas_version }}
+    - conda-forge::blas
     - boost
     - boost-cpp {{ boost_cpp_version }}
     - boto3

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - python
   run:
     - bokeh {{ bokeh_version }}
-    - conda-forge::blas{{ blas_version }}
+    - conda-forge::blas
     - cudatoolkit ={{ cuda_version }}.*
     - cupy {{ cupy_version }} # [cuda_compiler_version != "11.0"]
     - cupy {{ cuda11_cupy_version }} # [cuda_compiler_version == "11.0"]

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -37,8 +37,6 @@ benchmark_version:
   - '=1.5.1'
 black_version:
   - '=19.10'
-blas_version:
-  - '=2.14=openblas'
 bokeh_version:
   - '>=2.1.1'
 boost_cpp_version:


### PR DESCRIPTION
We have been pinning to `openblas`. However this causes us issues if we want to install `pytorch`, this runs into issues as they require `mkl`. So this relaxes `blas` to allow either implementation as desired.

cc @mike-wendt @kkraus14 @datametrician