### PR TITLE
Drop `async_generator`

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -38,7 +38,6 @@ requirements:
   run:
     - arrow-cpp {{ arrow_version }}
     - arrow-cpp-proc * cuda
-    - async_generator
     - autoconf
     - automake
     - benchmark {{ benchmark_version }}


### PR DESCRIPTION
This seems to primarily be a Python 3.5 backport package with a few features of Python 3.7 backported to Python 3.6 as well. In any event RAPIDS is Python 3.7+ at this point and this package appears to be unused (outside of an outdated reference in `ucx-py`). So go ahead and drop it since we don't use it.

https://github.com/search?q=org%3Arapidsai+async_generator&type=Code
https://github.com/search?q=org%3Arapidsai+asynccontextmanager&type=Code