### PR TITLE
[WIP] Drop ucx-py

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -132,7 +132,6 @@ requirements:
     - twine
     - ucx-proc=*=gpu
     - ucx
-    - ucx-py ={{ minor_version }}.*
     - umap-learn
 
 about:

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -131,6 +131,7 @@ requirements:
     - treelite {{ treelite_version }}
     - twine
     - ucx-proc=*=gpu
+    - ucx
     - ucx-py ={{ minor_version }}.*
     - umap-learn
 


### PR DESCRIPTION
Drops `ucx-py` to avoid having the package show up in `ucx-py`'s CI. Also explicitly lists `ucx`, which we need in all cases ( including `ucx-py` going forward https://github.com/rapidsai/ucx-py/pull/570 ).

Note: Marked as draft until we fix downstream projects to include this explicitly.

cc @mike-wendt