### PR TITLE
FIX Add 0.16 RAPIDS to nightly axis & remove `libcumlprims` from `rapids-build-env`

### DIFF
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -6,6 +6,7 @@ CONDA_CONFIG_FILE:
 
 RAPIDS_VER:
   - 0.15
+  - 0.16
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -81,7 +81,6 @@ requirements:
     - hypothesis
     - isort {{ isort_version }}
     - lapack
-    - libcumlprims ={{ minor_version }}.*
     - libcypher-parser
     - libgcc-ng {{ build_stack_version }}
     - libgfortran-ng {{ build_stack_version }}


### PR DESCRIPTION
This enables env/meta-pkg builds for v0.16 nightlies as burndown started yesterday.

It also removes `libcumlprims` from `rapids-build-env` as `libcumlprims` needs a `0.16` container to build which is blocked by getting these env-pkgs out. `cuML` already explicitly installs `libcumlprims` so removing this package should have no impact.

Blocks rapidsai/gpuci-build-environment#116
Blocks rapidsai/docker#138 (which is blocked by the above PR)