### PR TITLE
FIX Correct conda recipes to use RAPIDS version

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -19,7 +19,7 @@
 
 package:
   name: rapids-build-env
-  version: {{ version }}
+  version: {{ rapids_version }}
 
 source:
   git_url: ../../..

--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -18,7 +18,7 @@
 
 package:
   name: rapids-doc-env
-  version: {{ version }}
+  version: {{ rapids_version }}
 
 source:
   git_url: ../../..

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -19,7 +19,7 @@
 
 package:
   name: rapids-notebook-env
-  version: {{ version }}
+  version: {{ rapids_version }}
 
 source:
   git_url: ../../..

--- a/conda/recipes/rapids-xgboost/meta.yaml
+++ b/conda/recipes/rapids-xgboost/meta.yaml
@@ -19,7 +19,7 @@
 
 package:
   name: rapids-xgboost
-  version: {{ version }}
+  version: {{ rapids_version }}
 
 source:
   git_url: ../../..

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -19,7 +19,7 @@
 
 package:
   name: rapids
-  version: {{ version }}
+  version: {{ rapids_version }}
 
 source:
   git_url: ../../..


### PR DESCRIPTION
Currently the recipes use `version` which is based off of the tag in this repo. Switching this to `rapids_version` which uses the env var `RAPIDS_VER` specified by `./ci/axis/nightly.yaml` or `./ci/axis/release.yaml`. This way during burndown where we need to build multiple version from the `nightly.yaml` axis they will each get their respective version.

As it is right now they get the same version so while a `0.16` build shows as successful it is versioned as `0.15` and has a duplicate package.