### PR TITLE
Upgrade cmake to 3.17+

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -44,7 +44,7 @@ boost_cpp_version:
 clang_version:
   - '=8.0.1'
 cmake_version:
-  - '=3.14.5'
+  - '=3.18.0'
 cmake_setuptools_version:
   - '>=0.1.3'
 cupy_version:


### PR DESCRIPTION
cc @aleksficek as I'm guessing this has ccache integration interactions

CMake 3.17+ is needed to use new `FindCUDAToolkit` features which are required for https://github.com/rapidsai/rmm/pull/474 and will be required for all RAPIDS packages in the future.

We want to target 0.16 for this as opposed to 0.15.