### PR TITLE
Add mimesis for generating data in Python tests

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -91,6 +91,7 @@ requirements:
     - libwebp
     - lightgbm
     - make
+    - mimesis
     - moto
     - nccl {{ nccl_version }} # [cuda_compiler_version != "11.0"]
     - nccl {{ cuda11_nccl_version }} # [cuda_compiler_version == "11.0"]


### PR DESCRIPTION
https://github.com/rapidsai/cudf/pull/5843/ introduces a `dataset_synthesizer` module used by Python tests for automatically synthesizing datasets. `dataset_synthesizer` uses `mimesis` for randomly generating data.