### PR TITLE
FIX Use our nightly cupy for CUDA 11 and restrict numba <0.51

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -24,7 +24,7 @@ build_stack_version:
 
 # Overrides for CUDA 11 specific versions
 cuda11_cupy_version:
-  - '=8.0.0dev0'
+  - '=8.0.0dev.rapidsai0.15'
 cuda11_nccl_version:
   - '>=2.7.6.1,<3.0a0'
 cuda11_xgboost_version:
@@ -94,7 +94,7 @@ networkx_version:
 nodejs_version:
   - '>=12'
 numba_version:
-  - '>=0.49'
+  - '>=0.49,<0.51'
 numpy_version:
   - '>=1.17.3'
 pandas_version:


### PR DESCRIPTION
Until we get a cupy `7.8` build, use our nightly `8.0.0dev` for CUDA 11 builds. Given the current issues with numba `0.51` restrict numba so all builds only pull up to `0.50.x`. There is an effort to fix `0.51.0` numba but that may slip to `0.51.1`. This higher end pinning will prevent errors in builds that have been seen in multiple repos.

cc @gmarkall @kkraus14 