### PR TITLE
FIX Update test PATHs and remove duplicate installs

### DIFF
--- a/ci/test/cudf.sh
+++ b/ci/test/cudf.sh
@@ -4,6 +4,7 @@ set -x
 
 export HOME=$WORKSPACE
 export LIBCUDF_KERNEL_CACHE_PATH=$WORKSPACE/.cache/rapids/cudf
+export PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/cudf.sh
+++ b/ci/test/cudf.sh
@@ -7,10 +7,6 @@ export LIBCUDF_KERNEL_CACHE_PATH=$WORKSPACE/.cache/rapids/cudf
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids
-conda install -y -q -c conda-forge fastavro "rapidsai::cupy>=6.6.0,<8.0.0a0,!=7.1.0"
-pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
-pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
-pip install "git+https://github.com/python-streamz/streamz.git" --upgrade --no-deps
 env
 conda list
 

--- a/ci/test/cugraph.sh
+++ b/ci/test/cugraph.sh
@@ -3,6 +3,7 @@ set +e
 set -x
 export HOME=$WORKSPACE
 export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
+export PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids
@@ -12,9 +13,7 @@ cd /rapids/cugraph/datasets
 bash ./get_test_data.sh
 export RAPIDS_DATASET_ROOT_DIR=/rapids/cugraph/datasets
 
-# Install test deps
-pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
-pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
+# Show environment
 env
 conda list
 

--- a/ci/test/cuml.sh
+++ b/ci/test/cuml.sh
@@ -3,13 +3,10 @@ set +e
 
 export HOME=$WORKSPACE
 export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
+export PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids
-# FIXME: Install the master version of dask, distributed, and streamz
-pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
-pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
-pip install "git+https://github.com/python-streamz/streamz.git" --upgrade --no-deps
 env
 conda list
 

--- a/ci/test/cuspatial.sh
+++ b/ci/test/cuspatial.sh
@@ -3,6 +3,7 @@ set -ex
 
 export CUSPATIAL_HOME=/rapids/cuspatial
 export HOME=$WORKSPACE
+export PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/daskcuda.sh
+++ b/ci/test/daskcuda.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set +e
 set -x
+
+export PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids
-# FIXME: should this be in the container?
-# mwendt: this needs to be installed from `rapidsai` to keep the correct NCCL version already in the container
-#         cupy right now is only needed for testing so that is why cudf/daskcuda install it separately in their ci/gpu/build.sh
-conda install -y rapidsai::cupy
+
 env
 conda list
 

--- a/ci/test/daskcuda.sh
+++ b/ci/test/daskcuda.sh
@@ -15,10 +15,6 @@ TESTRESULTS_DIR=${WORKSPACE}/testresults
 mkdir -p ${TESTRESULTS_DIR}
 SUITEERROR=0
 
-# Install distributed@master (temporarily required due to issues with 2.3.2)
-pip install git+https://github.com/dask/distributed.git@master
-pip install pytest-asyncio fsspec
-
 # Python tests
 cd /rapids/dask-cuda/dask_cuda
 py.test --junitxml=${TESTRESULTS_DIR}/pytest.xml -v 

--- a/ci/test/daskcuda.sh
+++ b/ci/test/daskcuda.sh
@@ -2,6 +2,7 @@
 set +e
 set -x
 
+export HOME=$WORKSPACE 
 export PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
@@ -9,9 +10,6 @@ source /opt/conda/bin/activate rapids
 
 env
 conda list
-
-# mwendt: crucial redirect missing https://github.com/rapidsai/dask-cuda/blob/39eac0235a84dfd36ac0170e60a4cb3fdde17f47/ci/gpu/build.sh#L21
-export HOME=$WORKSPACE 
 
 TESTRESULTS_DIR=${WORKSPACE}/testresults
 mkdir -p ${TESTRESULTS_DIR}

--- a/ci/test/integration.sh
+++ b/ci/test/integration.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -ex
-. /opt/conda/etc/profile.d/conda.sh
-conda activate rapids
-
 export HOME=${WORKSPACE}
 export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
-export PATH="$PATH:/opt/conda/bin"
+export PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+. /opt/conda/etc/profile.d/conda.sh
+conda activate rapids
 
 gpuci_logger "Show env and current conda list"
 env


### PR DESCRIPTION
Jenkins on docker runs overwrites the container's `PATH` with the node's `PATH`. These patches reinstates the correct `PATH` prior to `conda activate`.

In addition, there are a number of conda/pip installs that are no longer necessary and are removed.