### PR TITLE
FIX Add /opt/conda/bin to Path Variable

### DIFF
--- a/ci/test/cudf.sh
+++ b/ci/test/cudf.sh
@@ -4,7 +4,7 @@ set -x
 
 export HOME=$WORKSPACE
 export LIBCUDF_KERNEL_CACHE_PATH=$WORKSPACE/.cache/rapids/cudf
-export PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/cudf.sh
+++ b/ci/test/cudf.sh
@@ -4,7 +4,7 @@ set -x
 
 export HOME=$WORKSPACE
 export LIBCUDF_KERNEL_CACHE_PATH=$WORKSPACE/.cache/rapids/cudf
-export PATH="/opt/conda/bin/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/cugraph.sh
+++ b/ci/test/cugraph.sh
@@ -3,7 +3,7 @@ set +e
 set -x
 export HOME=$WORKSPACE
 export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
-export PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/cugraph.sh
+++ b/ci/test/cugraph.sh
@@ -3,7 +3,7 @@ set +e
 set -x
 export HOME=$WORKSPACE
 export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
-export PATH="/opt/conda/bin/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/cuml.sh
+++ b/ci/test/cuml.sh
@@ -3,7 +3,7 @@ set +e
 
 export HOME=$WORKSPACE
 export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
-export PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/cuml.sh
+++ b/ci/test/cuml.sh
@@ -3,7 +3,7 @@ set +e
 
 export HOME=$WORKSPACE
 export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
-export PATH="/opt/conda/bin/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/cuspatial.sh
+++ b/ci/test/cuspatial.sh
@@ -3,7 +3,7 @@ set -ex
 
 export CUSPATIAL_HOME=/rapids/cuspatial
 export HOME=$WORKSPACE
-export PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/cuspatial.sh
+++ b/ci/test/cuspatial.sh
@@ -3,7 +3,7 @@ set -ex
 
 export CUSPATIAL_HOME=/rapids/cuspatial
 export HOME=$WORKSPACE
-export PATH="/opt/conda/bin/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/daskcuda.sh
+++ b/ci/test/daskcuda.sh
@@ -3,7 +3,7 @@ set +e
 set -x
 
 export HOME=$WORKSPACE 
-export PATH="/opt/conda/bin/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/daskcuda.sh
+++ b/ci/test/daskcuda.sh
@@ -3,7 +3,7 @@ set +e
 set -x
 
 export HOME=$WORKSPACE 
-export PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/integration.sh
+++ b/ci/test/integration.sh
@@ -2,7 +2,7 @@
 set -ex
 export HOME=${WORKSPACE}
 export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
-export PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids

--- a/ci/test/integration.sh
+++ b/ci/test/integration.sh
@@ -2,7 +2,7 @@
 set -ex
 export HOME=${WORKSPACE}
 export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
-export PATH="/opt/conda/bin/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids

--- a/ci/test/rmm.sh
+++ b/ci/test/rmm.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ex
 export HOME=$WORKSPACE
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids
 env


### PR DESCRIPTION
Builds off of changes in https://github.com/rapidsai/integration/pull/105

Adds `/opt/conda/bin` to beginning of `PATH` variable in test scripts.
> This is necessary so we can use tools install in the `base` environment like `gpuci-tools` in these scripts. We will install `gpuci-tools` into the `rapids` conda env to no longer need this as well