### PR TITLE
Set xgboost to 1.2.0 for all CUDA versions

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -59,7 +59,7 @@ EOF
   cat ${1}/conda_build_config.yaml
   # Build pkg
   gpuci_logger "Start conda build for '${1}'..."
-  conda build --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge -c defaults \
+  gpuci_conda_retry build --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge -c defaults \
               --python=${PYTHON_VER} -m ${CONDA_CONFIG_FILE} ${1}
 }
 

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -93,8 +93,7 @@ requirements:
     - make
     - mimesis
     - moto
-    - nccl {{ nccl_version }} # [cuda_compiler_version != "11.0"]
-    - nccl {{ cuda11_nccl_version }} # [cuda_compiler_version == "11.0"]
+    - nccl {{ nccl_version }}
     - networkx {{ networkx_version }}
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}

--- a/conda/recipes/rapids-xgboost/meta.yaml
+++ b/conda/recipes/rapids-xgboost/meta.yaml
@@ -36,8 +36,7 @@ requirements:
     - python
   run:
     - cudatoolkit ={{ cuda_version }}.*
-    - nccl {{ nccl_version }} # [cuda_compiler_version != "11.0"]
-    - nccl {{ cuda11_nccl_version }} # [cuda_compiler_version == "11.0"]
+    - nccl {{ nccl_version }}
     - python
     - xgboost {{ xgboost_version }}
 

--- a/conda/recipes/rapids-xgboost/meta.yaml
+++ b/conda/recipes/rapids-xgboost/meta.yaml
@@ -39,8 +39,7 @@ requirements:
     - nccl {{ nccl_version }} # [cuda_compiler_version != "11.0"]
     - nccl {{ cuda11_nccl_version }} # [cuda_compiler_version == "11.0"]
     - python
-    - xgboost {{ xgboost_version }} # [cuda_compiler_version != "11.0"]
-    - xgboost {{ cuda11_xgboost_version }} # [cuda_compiler_version == "11.0"]
+    - xgboost {{ xgboost_version }}
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -38,8 +38,7 @@ requirements:
     - cudatoolkit ={{ cuda_version }}.*
     - cupy {{ cupy_version }} # [cuda_compiler_version != "11.0"]
     - cupy {{ cuda11_cupy_version }} # [cuda_compiler_version == "11.0"]
-    - nccl {{ nccl_version }} # [cuda_compiler_version != "11.0"]
-    - nccl {{ cuda11_nccl_version }} # [cuda_compiler_version == "11.0"]
+    - nccl {{ nccl_version }}
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}
     - pickle5  # [py<38]

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -8,7 +8,7 @@ dask_xgboost_version:
 
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
-  - '=1.1.0dev.rapidsai0.15'
+  - '=1.2.0dev.rapidsai0.15'
 
 # Versions for conda
 conda_version:
@@ -27,8 +27,6 @@ cuda11_cupy_version:
   - '=8.0.0dev.rapidsai0.15'
 cuda11_nccl_version:
   - '>=2.7.6.1,<3.0a0'
-cuda11_xgboost_version:
-  - '=1.2.0dev.rapidsai0.15'
 
 # Shared versions across meta-pkgs
 arrow_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -25,8 +25,6 @@ build_stack_version:
 # Overrides for CUDA 11 specific versions
 cuda11_cupy_version:
   - '=8.0.0dev.rapidsai0.15'
-cuda11_nccl_version:
-  - '>=2.7.6.1,<3.0a0'
 
 # Shared versions across meta-pkgs
 arrow_version:
@@ -86,7 +84,7 @@ jupyterlab_version:
 librdkafka_version:
   - '=1.4.2'
 nccl_version:
-  - '=2.5'
+  - '>=2.7.6.1,<2.8'
 networkx_version:
   - '>=2.3'
 nodejs_version:


### PR DESCRIPTION
Xgboost 1.2.0dev.rapidsai0.15 nightlies are out supporting CUDA 10.1, 10.2, & 11.0.