### PR TITLE
Bump Dask + Distributed to 2.23.0

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -48,11 +48,11 @@ cupy_version:
 cython_version:
   - '>=0.29.14,<0.30'
 dask_version:
-  - '>=2.22.0'
+  - '>=2.23.0'
 datashader_version:
   - '>=0.10'
 distributed_version:
-  - '>=2.22.0'
+  - '>=2.23.0'
 dlpack_version:
   - '=0.2'
 double_conversion_version:


### PR DESCRIPTION
Includes this serialization performance improvement ( https://github.com/dask/distributed/pull/4004 ) amongst other things.