### PR TITLE
ENH Update numba versioning to pull 0.51

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -90,7 +90,7 @@ networkx_version:
 nodejs_version:
   - '>=12'
 numba_version:
-  - '>=0.49,<0.51'
+  - '>=0.49'
 numpy_version:
   - '>=1.17.3'
 pandas_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -90,7 +90,7 @@ networkx_version:
 nodejs_version:
   - '>=12'
 numba_version:
-  - '>=0.49'
+  - '>=0.49,!=0.51.0'
 numpy_version:
   - '>=1.17.3'
 pandas_version:


### PR DESCRIPTION
From successful GPU unit tests in rapidsai/cudf#5979 we are going to remove the restriciton that prevents use of numba 0.51 given the earlier timeout issues are resolve. Numba 0.51 brings CUDA 11 and Ampere support.