### PR TITLE
FIX cuDF Test Wrong GCC

### DIFF
--- a/ci/test/cudf.sh
+++ b/ci/test/cudf.sh
@@ -15,6 +15,11 @@ TESTRESULTS_DIR=${WORKSPACE}/testresults
 mkdir -p ${TESTRESULTS_DIR}
 SUITEERROR=0
 
+echo "HERE I AM@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
+which gcc
+which g++
+ccache -s
+
 # build gtests
 pushd /rapids/cudf/cpp/build
 make build_tests_cudf

--- a/ci/test/cudf.sh
+++ b/ci/test/cudf.sh
@@ -15,13 +15,6 @@ TESTRESULTS_DIR=${WORKSPACE}/testresults
 mkdir -p ${TESTRESULTS_DIR}
 SUITEERROR=0
 
-echo "HERE I AM@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
-which gcc
-which g++
-ccache -s
-export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/local/gcc7/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-echo PATH
-
 # build gtests
 pushd /rapids/cudf/cpp/build
 make build_tests_cudf

--- a/ci/test/cudf.sh
+++ b/ci/test/cudf.sh
@@ -4,7 +4,7 @@ set -x
 
 export HOME=$WORKSPACE
 export LIBCUDF_KERNEL_CACHE_PATH=$WORKSPACE/.cache/rapids/cudf
-export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/local/gcc7/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/cudf.sh
+++ b/ci/test/cudf.sh
@@ -19,6 +19,8 @@ echo "HERE I AM@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 which gcc
 which g++
 ccache -s
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/local/gcc7/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+echo PATH
 
 # build gtests
 pushd /rapids/cudf/cpp/build

--- a/ci/test/cugraph.sh
+++ b/ci/test/cugraph.sh
@@ -3,7 +3,7 @@ set +e
 set -x
 export HOME=$WORKSPACE
 export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
-export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/local/gcc7/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/cuml.sh
+++ b/ci/test/cuml.sh
@@ -3,7 +3,7 @@ set +e
 
 export HOME=$WORKSPACE
 export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
-export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/local/gcc7/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/cuspatial.sh
+++ b/ci/test/cuspatial.sh
@@ -3,7 +3,7 @@ set -ex
 
 export CUSPATIAL_HOME=/rapids/cuspatial
 export HOME=$WORKSPACE
-export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/local/gcc7/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/daskcuda.sh
+++ b/ci/test/daskcuda.sh
@@ -3,7 +3,7 @@ set +e
 set -x
 
 export HOME=$WORKSPACE 
-export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/local/gcc7/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids

--- a/ci/test/integration.sh
+++ b/ci/test/integration.sh
@@ -2,7 +2,7 @@
 set -ex
 export HOME=${WORKSPACE}
 export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
-export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/local/gcc7/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids

--- a/ci/test/rmm.sh
+++ b/ci/test/rmm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 export HOME=$WORKSPACE
-export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/local/gcc7/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids


### PR DESCRIPTION
cuDF builds not working on centos7 after recent nvcc PATH fix

The `PATH` variable needed to be updated to include `the gcc7` location when on centos7.

https://gpuci.gpuopenanalytics.com/job/rapidsai/job/nightly-tests/job/docker-test-cudf/

Open to ideas if there's a cleaner way to do this, this path works fine for ubuntu because `usr/local/gcc7` does not exist on it and is therefore skipped.