### PR TITLE
Tie xgboost version to rapids version

### DIFF
--- a/conda/recipes/rapids-xgboost/meta.yaml
+++ b/conda/recipes/rapids-xgboost/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - cudatoolkit ={{ cuda_version }}.*
     - nccl {{ nccl_version }}
     - python
-    - xgboost {{ xgboost_version }}
+    - xgboost {{ xgboost_version }}{{ minor_version }}
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -8,7 +8,7 @@ dask_xgboost_version:
 
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
-  - '=1.2.0dev.rapidsai0.15'
+  - '=1.2.0dev.rapidsai'
 
 # Versions for conda
 conda_version:


### PR DESCRIPTION
This resolves the v0.16 builds that are failing. Except for v0.16 CUDA 11 builds since those packages aren't available yet.