### PR TITLE
datashader version supporting cuDF 0.14 and above

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -50,7 +50,7 @@ cython_version:
 dask_version:
   - '>=2.23.0'
 datashader_version:
-  - '>=0.10'
+  - '>=0.11.1'
 distributed_version:
   - '>=2.23.0'
 dlpack_version:


### PR DESCRIPTION
Updating datashader version to 0.11.1 to resolve issues supporting cuDF 0.14 and above. This also requires numba >= 0.51.2, dependent on #109 being resolved.