### PR TITLE
Bump pandas to >=1.0,<1.2.0dev0

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -94,7 +94,7 @@ numba_version:
 numpy_version:
   - '>=1.17.3'
 pandas_version:
-  - '>=1.0,<1.2'
+  - '>=1.0,<1.2.0dev0'
 pandoc_version:
   - '<=2.0.0'
 panel_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -94,7 +94,7 @@ numba_version:
 numpy_version:
   - '>=1.17.3'
 pandas_version:
-  - '>=1.0,<1.1.0a0'
+  - '>=1.0,<1.2'
 pandoc_version:
   - '<=2.0.0'
 panel_version:


### PR DESCRIPTION
Pandas 1.1+ contains several bug fixes for tests in cuDF that we currently need to xfail. These include some json writer tests as well as string related functionality that was broken in 1.0. In addition there are improvements to the nullable dtype feature set and updates to groupby to maintain consistency across aggregations. Supporting a wider range of pandas versions lets us close the gap between cudf and pandas behavior while maintaining backwards compatibility for people who have not upgraded to 1.1 yet. 