### PR TITLE
ENH Update cupy version for CUDA 11

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -53,8 +53,7 @@ requirements:
     - conda-build {{ conda_build_version }}
     - conda-verify {{ conda_verify_version }}
     - cudatoolkit ={{ cuda_version }}.*
-    - cupy {{ cupy_version }} # [cuda_compiler_version != "11.0"]
-    - cupy {{ cuda11_cupy_version }} # [cuda_compiler_version == "11.0"]
+    - cupy {{ cupy_version }}
     - cython {{ cython_version }}
     - dask {{ dask_version }}
     - dask-ml

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -38,8 +38,7 @@ requirements:
     - bokeh {{ bokeh_version }}
     - conda-forge::blas
     - cudatoolkit ={{ cuda_version }}.*
-    - cupy {{ cupy_version }} # [cuda_compiler_version != "11.0"]
-    - cupy {{ cuda11_cupy_version }} # [cuda_compiler_version == "11.0"]
+    - cupy {{ cupy_version }}
     - cython {{ cython_version }}
     - dask-labextension
     - dask-ml

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -36,8 +36,7 @@ requirements:
     - python
   run:
     - cudatoolkit ={{ cuda_version }}.*
-    - cupy {{ cupy_version }} # [cuda_compiler_version != "11.0"]
-    - cupy {{ cuda11_cupy_version }} # [cuda_compiler_version == "11.0"]
+    - cupy {{ cupy_version }}
     - nccl {{ nccl_version }}
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -22,10 +22,6 @@ conda_verify_version:
 build_stack_version:
   - '=7.5.0'
 
-# Overrides for CUDA 11 specific versions
-cuda11_cupy_version:
-  - '=8.0.0dev.rapidsai0.15'
-
 # Shared versions across meta-pkgs
 arrow_version:
   - '=0.17.1'


### PR DESCRIPTION
Remove pin to `v8.0.0dev` and use `v7.8.0dev` for release. Once a CUDA 11 version of cupy 7.8 is on conda-forge we will remove our dev builds from `rapidsai-nightly` channel.