### PR TITLE
pinning doxygen version to avoid potential confusion

### DIFF
--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - pip
   run:
     - beautifulsoup4
-    - doxygen
+    - doxygen=1.8.20
     - markdown
     - nbsphinx
     - numpydoc

--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - pip
   run:
     - beautifulsoup4
-    - doxygen=1.8.20
+    - doxygen {{ doxygen_version }}
     - markdown
     - nbsphinx
     - numpydoc

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -53,6 +53,8 @@ dlpack_version:
   - '=0.2'
 double_conversion_version:
   - '=3.1.5'
+doxygen_version:
+  - '>=1.8.12,<=1.8.20'
 faiss_version:
   - '>=1.6.3'
 fastavro_version:


### PR DESCRIPTION
This helps avoid surprises like the one that happened with cuML here: https://github.com/rapidsai/cuml/pull/2769.