### PR TITLE
Re-enable cuxfilter

### DIFF
--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -5,7 +5,7 @@ CONDA_CONFIG_FILE:
   - conda/recipes/versions.yaml
 
 RAPIDS_VER:
-  - 0.15.0
+  - 0.15.1
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -48,6 +48,7 @@ requirements:
     - cusignal ={{ minor_version }}.*
     - cuspatial ={{ minor_version }}.*
     - custreamz ={{ minor_version }}.*
+    - cuxfilter ={{ minor_version }}.*
     - dask-cuda ={{ minor_version }}.*
     - dask-xgboost {{ dask_xgboost_version }}
     - rapids-xgboost ={{ minor_version }}.*

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -86,7 +86,7 @@ networkx_version:
 nodejs_version:
   - '>=12'
 numba_version:
-  - '>=0.49,!=0.51.0'
+  - '>=0.51.2'
 numpy_version:
   - '>=1.17.3'
 pandas_version:


### PR DESCRIPTION
Updates the numba pining to match `cuxfilter` and adds back `cuxfilter` to the meta package.