### PR TITLE
Add and pin libcumlprims to rapids-build-env

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -80,6 +80,7 @@ requirements:
     - isort {{ isort_version }}
     - lapack
     - libcypher-parser
+    - libcumlprims {{ libcumlprims_version }}
     - libgcc-ng {{ build_stack_version }}
     - libgfortran-ng {{ build_stack_version }}
     - libhwloc

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -81,6 +81,8 @@ jupyterlab_version:
   - '=2.1'
 librdkafka_version:
   - '=1.4.2'
+libcumlprims_version:
+  - '=0.16.0a200821'
 nccl_version:
   - '>=2.7.6.1,<2.8'
 networkx_version:


### PR DESCRIPTION
From a Slack discussion with @dantegd and @divyegala, it was determined that it would be a good idea to pin `libcumlprims` to the version in the link below in order to prevent build errors such as the current ones in Jenkins [shown here](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/docker/job/rapidsai-devel/111/).

https://github.com/rapidsai/cuml/blob/branch-0.16/conda/recipes/libcuml/meta.yaml#L44