### PR TITLE
Add jupyter_sphinx to doc-env

### DIFF
--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -36,6 +36,7 @@ requirements:
   run:
     - beautifulsoup4
     - doxygen {{ doxygen_version }}
+    - jupyter_sphinx
     - markdown
     - nbsphinx
     - numpydoc


### PR DESCRIPTION
This PR adds `jupyter_sphinx` to the `rapids-doc-env` since it is needed by `cuxfilter` to build docs.

It was originally added in the configuration of this Jenkins job, but never added to the integration repo:
https://gpuci.gpuopenanalytics.com/job/rapidsai/job/doc-builds/job/cuxfilter-docs-build

It is necessary now to prevent errors in the new doc-build jobs as seen here:
https://gpuci.gpuopenanalytics.com/job/rapidsai/job/doc-builds/job/docs-build/117/console