### PR TITLE
[REVIEW]Add nltk to rapids-build-env

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -130,6 +130,7 @@ requirements:
     - ucx-proc=*=gpu
     - ucx
     - umap-learn
+    - nltk
 
 about:
   home: http://rapids.ai/


### PR DESCRIPTION
Add nltk to rapids-build-env/meta.yaml . 

We need `nltk` for adding a test for the porter stemmer implementation in PR https://github.com/rapidsai/cuml/pull/2476 . 

