### PR TITLE
Fix test_pagerank.py

### DIFF
--- a/test/cugraph/test_pagerank.py
+++ b/test/cugraph/test_pagerank.py
@@ -86,13 +86,11 @@ def test_pagerank() :
     import cugraph
 
     gdf = read_csv_file(csvFile)
-    sources = gdf['0']
-    destinations = gdf['1']
 
     # Assuming that data has been loaded into a cuDF (using read_csv) Dataframe
     # create a Graph using the source and destination vertex pairs
     G = cugraph.Graph()
-    G.add_edge_list(sources, destinations, None)
+    G.from_cudf_edgelist(gdf, "0", "1")
 
     # Call cugraph.pagerank to get the pagerank scores
     # Sort values since renumbering may have changed expected order


### PR DESCRIPTION
This PR fixes `test_pagerank.py` so that integration tests can pass. They were failing in [this job](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/integration/job/prb/job/rapids-integration-tests/56/).

I followed the instructions from [TRANSITIONGUIDE.md](https://github.com/rapidsai/cugraph/blob/branch-0.16/TRANSITIONGUIDE.md#loading-an-edge-list-1).

This PR is necessary for #131 to pass.