### PR TITLE
Add missing notebook dependencies

### DIFF
--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -5,14 +5,14 @@
 {% set cuda_version = '.'.join(environ.get('CUDA_VERSION', '10.0').split('.')[:2]) %}
 {% set py_version = environ.get('CONDA_PY', 36) %}
 
-### 
+###
 # Versions referenced below are set in `conda/recipe/*versions.yaml` except for
 #   those set above (e.g. `cuda_version`)
 #
-# gpuCI loads the correct file based on the build type (NIGHTLY or RELEASE) in 
+# gpuCI loads the correct file based on the build type (NIGHTLY or RELEASE) in
 #   `ci/cpu/build-env.sh` and `ci/axis/*.yaml`
 #
-# Manual builds need to use the `conda build` flag of `-m <path-to-file>.yaml` 
+# Manual builds need to use the `conda build` flag of `-m <path-to-file>.yaml`
 #   to set these versions
 ###
 
@@ -42,6 +42,7 @@ requirements:
     - cython {{ cython_version }}
     - dask-labextension
     - dask-ml
+    - holoviews
     - ipython {{ ipython_version }}
     - jupyter-server-proxy
     - jupyterlab {{ jupyterlab_version }}
@@ -49,6 +50,7 @@ requirements:
     - networkx
     - nodejs {{ nodejs_version }}
     - pytest
+    - s3fs
     - scikit-learn {{ scikit_learn_version }}
     - scipy {{ scipy_version }}
     - seaborn


### PR DESCRIPTION
This PR adds some missing notebook dependencies, `s3fs` and `holoviews`, that were brought up in the `rapidsai/docker` repo issues below.

https://github.com/rapidsai/docker/issues/147
https://github.com/rapidsai/docker/issues/157