### PR TITLE
[REVIEW] Add mypy 0.782 to rapids-build-env

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -92,6 +92,7 @@ requirements:
     - make
     - mimesis
     - moto
+    - mypy {{ mypy_version }}
     - nccl {{ nccl_version }}
     - networkx {{ networkx_version }}
     - nltk

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -81,6 +81,8 @@ jupyterlab_version:
   - '=2.1'
 librdkafka_version:
   - '=1.4.2'
+mypy_version:
+  - '0.782'
 nccl_version:
   - '>=2.7.6.1,<2.8'
 networkx_version:


### PR DESCRIPTION
This is intended for use in cuDF 0.17, but shouldn't hurt to merge earlier.