### PR TITLE
Add networkx to rapids environment

### DIFF
--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -5,14 +5,14 @@
 {% set cuda_version = '.'.join(environ.get('CUDA_VERSION', '10.0').split('.')[:2]) %}
 {% set py_version = environ.get('CONDA_PY', 36) %}
 
-### 
+###
 # Versions referenced below are set in `conda/recipe/*versions.yaml` except for
 #   those set above (e.g. `cuda_version`)
 #
-# gpuCI loads the correct file based on the build type (NIGHTLY or RELEASE) in 
+# gpuCI loads the correct file based on the build type (NIGHTLY or RELEASE) in
 #   `ci/cpu/build-env.sh` and `ci/axis/*.yaml`
 #
-# Manual builds need to use the `conda build` flag of `-m <path-to-file>.yaml` 
+# Manual builds need to use the `conda build` flag of `-m <path-to-file>.yaml`
 #   to set these versions
 ###
 
@@ -46,7 +46,7 @@ requirements:
     - jupyter-server-proxy
     - jupyterlab {{ jupyterlab_version }}
     - matplotlib
-    - networkx
+    - networkx {{ networkx_version }}
     - nodejs {{ nodejs_version }}
     - pytest
     - scikit-learn {{ scikit_learn_version }}

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -5,14 +5,14 @@
 {% set cuda_version = '.'.join(environ.get('CUDA_VERSION', '10.0').split('.')[:2]) %}
 {% set py_version = environ.get('CONDA_PY', 36) %}
 
-### 
+###
 # Versions referenced below are set in `conda/recipe/*versions.yaml` except for
 #   those set above (e.g. `cuda_version`)
 #
-# gpuCI loads the correct file based on the build type (NIGHTLY or RELEASE) in 
+# gpuCI loads the correct file based on the build type (NIGHTLY or RELEASE) in
 #   `ci/cpu/build-meta.sh` and `ci/axis/*.yaml`
 #
-# Manual builds need to use the `conda build` flag of `-m <path-to-file>.yaml` 
+# Manual builds need to use the `conda build` flag of `-m <path-to-file>.yaml`
 #   to set these versions
 ###
 
@@ -38,6 +38,7 @@ requirements:
     - cudatoolkit ={{ cuda_version }}.*
     - cupy {{ cupy_version }}
     - nccl {{ nccl_version }}
+    - networkx {{ networkx_version }}
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}
     - pickle5  # [py<38]
@@ -68,8 +69,8 @@ about:
   license_file: conda/recipes/rapids/LICENSE
   summary: 'RAPIDS Suite - Open GPU Data Science'
   description: |
-    Meta-package for the RAPIDS suite of software libraries. RAPIDS gives you the freedom to execute end-to-end data science 
-    and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, 
+    Meta-package for the RAPIDS suite of software libraries. RAPIDS gives you the freedom to execute end-to-end data science
+    and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization,
     but exposes that GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.
   doc_url: https://docs.rapids.ai/
   dev_url: https://github.com/rapidsai/


### PR DESCRIPTION
PR #136 has some build CI failures due to a missing `networkx` dependency when importing `cugraph` for the `rapids` meta-package ([link to Jenkins failure log](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/integration/job/prb/job/meta-pkg-nightly-build/246/CONDA_CONFIG_FILE=conda%2Frecipes%2Fversions.yaml,CONDA_USERNAME=rapidsai-nightly,CUDA_VER=10.2,DEFAULT_CUDA_VER=10.1,PYTHON_VER=3.7,RAPIDS_VER=0.16.0a/console)). This PR adds the missing depedency.

I believe this dependency was introduced in the following cugraph PR https://github.com/rapidsai/cugraph/pull/1147/

This PR also adds a version pin for `networkx` in the `notebook-env` since that was missing.