### PR TITLE
[REVIEW] Allow cuPy 8

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -40,7 +40,7 @@ cmake_version:
 cmake_setuptools_version:
   - '>=0.1.3'
 cupy_version:
-  - '>=7.1.0,<8.0.0a0'
+  - '>=7.1.0,<9.0.0a0'
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -40,7 +40,7 @@ cmake_version:
 cmake_setuptools_version:
   - '>=0.1.3'
 cupy_version:
-  - '>=7.1.0,<9.0.0a0'
+  - '>7.1.0,<9.0.0a0'
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:


### PR DESCRIPTION
Both cuML and cuSignal would like to move to cuPy 8 and have done initial testing with it. This change does not eliminate 7.x support, just allows 8.x.﻿
