### PR TITLE
Require `nvtx`

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -98,6 +98,7 @@ requirements:
     - nltk
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}
+    - nvtx {{ nvtx_version }}
     - pandas {{ pandas_version }}
     - panel {{ panel_version }}
     - pickle5  # [py<38]

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - networkx {{ networkx_version }}
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}
+    - nvtx {{ nvtx_version }}
     - pickle5  # [py<38]
     - python
     - cudf ={{ minor_version }}.*

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -93,6 +93,8 @@ numba_version:
   - '>=0.51.2'
 numpy_version:
   - '>=1.17.3'
+nvtx_version:
+  - '>=0.2.1,<0.3'
 pandas_version:
   - '>=1.0,<1.2.0dev0'
 pandoc_version:


### PR DESCRIPTION
Adds the `nvtx` package to our build and deployment environments. As this has been refactored out of cuDF, this adds it as an explicit requirement to make sure that functionality is retained.

xref: https://github.com/rapidsai/cudf/pull/6413

cc @shwina @kkraus14