### PR TITLE
Add v0.17 to axis

### DIFF
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -6,6 +6,7 @@ CONDA_CONFIG_FILE:
 
 RAPIDS_VER:
   - 0.16.0a
+  - 0.17.0a
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:


### PR DESCRIPTION
This won't pass all of the tests I believe, but is necessary to get v0.17 `rapids-build-env` available for projects.