### PR TITLE
Remove dask-xgboost

### DIFF
--- a/conda/recipes/rapids-xgboost/meta.yaml
+++ b/conda/recipes/rapids-xgboost/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - cudatoolkit ={{ cuda_version }}.*
     - nccl {{ nccl_version }}
     - python
-    - xgboost {{ xgboost_version }}{{ minor_version }}
+    - xgboost {{ xgboost_version }}
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/rapids-xgboost/meta.yaml
+++ b/conda/recipes/rapids-xgboost/meta.yaml
@@ -5,14 +5,14 @@
 {% set cuda_version = '.'.join(environ.get('CUDA_VERSION', '10.0').split('.')[:2]) %}
 {% set py_version = environ.get('CONDA_PY', 36) %}
 
-### 
+###
 # Versions referenced below are set in `conda/recipe/*versions.yaml` except for
 #   those set above (e.g. `cuda_version`)
 #
-# gpuCI loads the correct file based on the build type (NIGHTLY or RELEASE) in 
+# gpuCI loads the correct file based on the build type (NIGHTLY or RELEASE) in
 #   `ci/cpu/build-meta.sh` and `ci/axis/*.yaml`
 #
-# Manual builds need to use the `conda build` flag of `-m <path-to-file>.yaml` 
+# Manual builds need to use the `conda build` flag of `-m <path-to-file>.yaml`
 #   to set these versions
 ###
 

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -52,7 +52,6 @@ requirements:
     - custreamz ={{ minor_version }}.*
     - cuxfilter ={{ minor_version }}.*
     - dask-cuda ={{ minor_version }}.*
-    - dask-xgboost {{ dask_xgboost_version }}
     - rapids-xgboost ={{ minor_version }}.*
     - rmm ={{ minor_version }}.*
 

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -8,7 +8,7 @@ dask_xgboost_version:
 
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
-  - '=1.2.0dev.rapidsai'
+  - '=1.2.0dev.rapidsai0.16'
 
 # Versions for conda
 conda_version:


### PR DESCRIPTION
dask-xgboost was deprecated in v0.15 and to be removed in v0.16.