### PR TITLE
[REVIEW] Add nvtx package and bump cupy version

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -98,6 +98,7 @@ requirements:
     - nltk
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}
+    - nvtx {{ nvtx_version }}
     - pandas {{ pandas_version }}
     - panel {{ panel_version }}
     - pickle5  # [py<38]

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - networkx {{ networkx_version }}
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}
+    - nvtx {{ nvtx_version }}
     - pickle5  # [py<38]
     - python
     - cudf ={{ minor_version }}.*

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -40,7 +40,7 @@ cmake_version:
 cmake_setuptools_version:
   - '>=0.1.3'
 cupy_version:
-  - '>=7.1.0,<8.0.0a0'
+  - '>7.1.0,<9.0.0a0'
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -93,6 +93,8 @@ numba_version:
   - '>=0.51.2'
 numpy_version:
   - '>=1.17.3'
+nvtx_version:
+  - '>=0.2.1,<0.3'
 pandas_version:
   - '>=1.0,<1.2.0dev0'
 pandoc_version:


### PR DESCRIPTION
This is required for https://github.com/rapidsai/cudf/pull/6413

Looks like there was a timing issue while merging this PR: https://github.com/rapidsai/integration/pull/141 and creating `branch-0.17`, so the package addition did not come into `branch-0.17`.

