### PR TITLE
[REVIEW] pin faiss to =1.6.3

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -56,7 +56,7 @@ double_conversion_version:
 doxygen_version:
   - '>=1.8.12,<=1.8.20'
 faiss_version:
-  - '>=1.6.3'
+  - '=1.6.3'
 fastavro_version:
   - '>=0.22.0'
 flake8_version:


### PR DESCRIPTION
faiss had some file re-organization, so there is a good chance that the next release could be incompatible with cuML as it is right now.