### PR TITLE
FIX Add `setuptools` to `rapids` meta pkg

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -44,6 +44,7 @@ requirements:
     - nvtx {{ nvtx_version }}
     - pickle5  # [py<38]
     - python
+    - setuptools {{ setuptools_version }}
     - cudf ={{ minor_version }}.*
     - cugraph ={{ minor_version }}.*
     - cuml ={{ minor_version }}.*

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -115,6 +115,8 @@ scikit_learn_version:
   - '=0.23.1'
 scipy_version:
   - '=1.5.1'
+setuptools_version:
+  - '>=49,<50'
 spdlog_version:
   - '=1.7.0'
 sphinx_markdown_tables_version:


### PR DESCRIPTION
Adding `setuptools` pin to `rapids` meta-pkg to ensure the pin takes precedence over others. Previously we've relied on the pins with the dependencies of `rapids`, but there are conflicts with `cupy` and other packages that do not have a set pin. Having it as a direct dependency will make the solver respect the pin in all solves.