### PR TITLE
Use `matplotlib-base` instead of `matplotlib`

### DIFF
--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - ipython {{ ipython_version }}
     - jupyter-server-proxy
     - jupyterlab {{ jupyterlab_version }}
-    - matplotlib
+    - matplotlib-base
     - networkx {{ networkx_version }}
     - nodejs {{ nodejs_version }}
     - pytest


### PR DESCRIPTION
The `matplotlib` package ships with a `qt` dependency, which we don't need or use in the notebook. Not too mention this is a quite heavyweight dependency. So use `matplotlib-base` instead. This has just enough of the goodies to allow matplotlib to work from a notebook or usable as a dependency. Should help lighten our containers and simplify installs for people.