### PR TITLE
Upgrade Treelite to 0.93

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -122,4 +122,4 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=0.92'
+  - '=0.93'


### PR DESCRIPTION
Upgrade Treelite to 0.93 to use Protobuf 3.13. The version 0.93 is a very minor revision of 0.92. @JohnZed @kkraus14