### PR TITLE
Notebook updates

### DIFF
--- a/ci/test/notebooks.sh
+++ b/ci/test/notebooks.sh
@@ -6,6 +6,11 @@ set -o pipefail
 export LIBCUDF_KERNEL_CACHE_PATH=${WORKSPACE}/.jitcache
 
 source /opt/conda/bin/activate rapids
+
+# PyTorch is intentionally excluded from our Docker images due
+# to its size, but some notebooks still depend on it.
+conda install -y -c pytorch pytorch
+
 env
 /test.sh 2>&1 | tee nbtest.log
 EXITCODE=$?

--- a/ci/test/notebooks.sh
+++ b/ci/test/notebooks.sh
@@ -9,7 +9,16 @@ source /opt/conda/bin/activate rapids
 
 # PyTorch is intentionally excluded from our Docker images due
 # to its size, but some notebooks still depend on it.
-conda install -y -c pytorch pytorch
+case "${CUDA_VER}" in
+"10.1" | "10.2")
+    conda install -y -c pytorch pytorch
+    ;;
+*)
+    echo "Unsupported CUDA version for pytorch."
+    echo "Not installing pytorch."
+    ;;
+esac
+
 
 env
 /test.sh 2>&1 | tee nbtest.log

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -42,6 +42,7 @@ requirements:
     - cython {{ cython_version }}
     - dask-labextension
     - dask-ml
+    - filterpy
     - holoviews
     - ipython {{ ipython_version }}
     - jupyter-server-proxy


### PR DESCRIPTION
This PR includes the following changes:

- Adds `filterpy` to `rapids-notebook-env` for [this cusignal notebook](https://github.com/rapidsai/cusignal/blob/branch-0.16/notebooks/api_guide/estimation_examples.ipynb)
- Adds `pytorch` to our notebooks CI test scripts. `pytorch` is intentionally excluded from our images due to its size, however some notebooks still depend on it (i.e. cusignal's [E2E_Example.ipynb](https://github.com/rapidsai/cusignal/blob/branch-0.16/notebooks/E2E_Example.ipynb)). Adding it here will prevent such notebooks from failing CI tests.