### PR TITLE
ENH Remove conda from `build-env` and update conda-build version

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -49,7 +49,6 @@ requirements:
     - conda-forge::clang-tools {{ clang_version }}
     - cmake {{ cmake_version }}
     - cmake_setuptools {{ cmake_setuptools_version }}
-    - conda {{ conda_version }}
     - conda-build {{ conda_build_version }}
     - conda-verify {{ conda_verify_version }}
     - cudatoolkit ={{ cuda_version }}.*

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -11,8 +11,6 @@ xgboost_version:
   - '=1.2.0dev.rapidsai0.16'
 
 # Versions for conda
-conda_version:
-  - '=4.8.3'
 conda_build_version:
   - '=3.20.3'
 conda_verify_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -12,9 +12,9 @@ xgboost_version:
 
 # Versions for conda
 conda_version:
-  - '=4.7.12'
+  - '=4.8.3'
 conda_build_version:
-  - '=3.18.11'
+  - '=3.20.3'
 conda_verify_version:
   - '=3.1.1'
 


### PR DESCRIPTION
- Supports rapidsai/gpuci-build-environment#135 where we are updating the base containers to use conda `4.8.3` up from `4.7.12`
- Updates `conda-build` to `3.20.3` from `3.18.11`
- Removes `conda` from `rapids-build-env` as the double install causes issues with `gpuci-tools` and conda solving
  - Changes made in rapidsai/gpuci-build-environment#135 will prevent conda from auto-updating to remain at `4.8.3` as we've had issues with the latest versions of conda in the past
  - Given this locked conda version, it is safe for us to remove conda from the `build-env` pkg