### PR TITLE
Revert #154 removal of conda, keeps conda/conda-build version updates

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -49,6 +49,7 @@ requirements:
     - conda-forge::clang-tools {{ clang_version }}
     - cmake {{ cmake_version }}
     - cmake_setuptools {{ cmake_setuptools_version }}
+    - conda {{ conda_version }}
     - conda-build {{ conda_build_version }}
     - conda-verify {{ conda_verify_version }}
     - cudatoolkit ={{ cuda_version }}.*

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -11,8 +11,10 @@ xgboost_version:
   - '=1.2.0dev.rapidsai0.16'
 
 # Versions for conda
+conda_version:
+  - '=4.7.12'
 conda_build_version:
-  - '=3.20.3'
+  - '=3.18.11'
 conda_verify_version:
   - '=3.1.1'
 

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -12,9 +12,9 @@ xgboost_version:
 
 # Versions for conda
 conda_version:
-  - '=4.7.12'
+  - '=4.8.3'
 conda_build_version:
-  - '=3.18.11'
+  - '=3.20.3'
 conda_verify_version:
   - '=3.1.1'
 


### PR DESCRIPTION
Reverts #154 removal of `conda` as that leads to a version mismatch in the `rapids` env. Where the `base` env is `4.8.3` but `rapids` is `4.8.5` as it is not pinned in the `build-env` pkg anymore.

This PR keeps the version bumps to `conda` and `conda-build` from #154