### PR TITLE
[REVIEW] Upgrade cmake to 3.18

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -36,7 +36,7 @@ boost_cpp_version:
 clang_version:
   - '=8.0.1'
 cmake_version:
-  - '=3.17'
+  - '=3.18'
 cmake_setuptools_version:
   - '>=0.1.3'
 cupy_version:


### PR DESCRIPTION
There's some new features in CMake 3.18 that we want to start taking advantage of.

Depends on:
- https://github.com/rapidsai/cudf/pull/6545
- https://github.com/rapidsai/cuml/pull/3000
- https://github.com/rapidsai/cugraph/pull/1227
- https://github.com/rapidsai/cuspatial/pull/310
- https://github.com/rapidsai/clx/pull/263