### PR TITLE
[REVIEW] FIX Pin pytorch to avoid incorrect solving

### DIFF
--- a/ci/test/notebooks.sh
+++ b/ci/test/notebooks.sh
@@ -11,7 +11,7 @@ source /opt/conda/bin/activate rapids
 # to its size, but some notebooks still depend on it.
 case "${CUDA_VER}" in
 "10.1" | "10.2")
-    conda install -y -c pytorch pytorch
+    conda install -y -c pytorch "pytorch>=1.4"
     ;;
 *)
     echo "Unsupported CUDA version for pytorch."


### PR DESCRIPTION
Without the pin, pytorch can resolve to 1.0.0 which existed before `cudatoolkit`, so it lacked the proper dependency check on CUDA.