### PR TITLE
Ignore missing files during conda pack

### DIFF
--- a/ci/cpu/conda-pack.sh
+++ b/ci/cpu/conda-pack.sh
@@ -14,7 +14,7 @@ conda install -y -c $CONDA_USERNAME -c nvidia -c conda-forge -c defaults \
     ipykernel
 
 echo "Packing conda environment"
-conda-pack --quiet -n $CONDA_ENV_NAME -o ${CONDA_ENV_NAME}.tar.gz
+conda-pack --quiet --ignore-missing-files -n $CONDA_ENV_NAME -o ${CONDA_ENV_NAME}.tar.gz
 
 export AWS_DEFAULT_REGION="us-east-2"
 echo "Upload packed conda"


### PR DESCRIPTION
Note: this is for `branch-0.16`

The package for python 3.8.5 has issues with conda pack (see https://github.com/conda/conda-pack/issues/145#issuecomment-695813111). 

Adding `--ignore-missing-files` should resolve the error.