### PR TITLE
Update notebook tests

### DIFF
--- a/ci/test/notebooks.sh
+++ b/ci/test/notebooks.sh
@@ -10,7 +10,7 @@ source /opt/conda/bin/activate rapids
 # PyTorch is intentionally excluded from our Docker images due
 # to its size, but some notebooks still depend on it.
 case "${CUDA_VER}" in
-"10.1" | "10.2")
+"10.1" | "10.2" | "11.0")
     conda install -y -c pytorch "pytorch>=1.4"
     ;;
 *)


### PR DESCRIPTION
This PR updates the `ci/test/notebooks.sh` file since `pytorch` supports CUDA 11.0 now ([src](https://anaconda.org/pytorch/pytorch/files)). I left the `case` statement intact since we will likely be in a similar situation for CUDA 11.1, where RAPIDS supports it before `pytorch` does.