### PR TITLE
[REVIEW] updated clang version to 11.0.0

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -34,7 +34,7 @@ bokeh_version:
 boost_cpp_version:
   - '=1.72.0'
 clang_version:
-  - '=8.0.1'
+  - '=11.0.0'
 cmake_version:
   - '=3.17'
 cmake_format_version:


### PR DESCRIPTION
## Why update?
If we want to enable running clang-tidy on .cu files, v8.0.1 does not even support CTK version 10, as described here: https://github.com/rapidsai/raft/pull/85. Thus, we need to update clang version.

## Any risks due to this update?
None so far. I have tested this by running clang-tidy and clang-format on both cuML and raft repo's:
1. https://github.com/rapidsai/cuml/pull/3121
2. https://github.com/rapidsai/raft/pull/89

Specifically, the set of changes caused by clang-format is almost negligible.