### PR TITLE
add axis for python 3.9 tests

### DIFF
--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -19,3 +19,4 @@ LINUX_VER:
 
 PYTHON_VER:
   - 3.7
+  - 3.9


### PR DESCRIPTION
This PR adds python 3.9 target to the CI axis herein