### PR TITLE
Make conda-pack uploads public

### DIFF
--- a/ci/cpu/conda-pack.sh
+++ b/ci/cpu/conda-pack.sh
@@ -18,4 +18,4 @@ conda-pack --quiet --ignore-missing-files -n $CONDA_ENV_NAME -o ${CONDA_ENV_NAME
 
 export AWS_DEFAULT_REGION="us-east-2"
 echo "Upload packed conda"
-aws s3 cp --quiet ${CONDA_ENV_NAME}.tar.gz s3://rapidsai-data/conda-pack/${CONDA_USERNAME}/${CONDA_ENV_NAME}.tar.gz
+aws s3 cp --quiet --acl public-read ${CONDA_ENV_NAME}.tar.gz s3://rapidsai-data/conda-pack/${CONDA_USERNAME}/${CONDA_ENV_NAME}.tar.gz


### PR DESCRIPTION
Per https://github.com/rapidsai/ops/issues/1288 new uploads were not publicly accessible. This PR makes it so all uploads are public.