### PR TITLE
Match kafka version in libcudf_kafka

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -82,7 +82,7 @@ isort_version:
 jupyterlab_version:
   - '=2.1'
 librdkafka_version:
-  - '=1.5.0'
+  - '=1.5.*'
 mypy_version:
   - '0.782'
 nccl_version:


### PR DESCRIPTION
Match the version of `librdkafka` in `libcudf_kafka` (https://github.com/rapidsai/cudf/blob/branch-0.17/conda/recipes/libcudf_kafka/meta.yaml#L29).