### PR TITLE
XGBoost version is based on rapids minor version

### DIFF
--- a/conda/recipes/rapids-xgboost/meta.yaml
+++ b/conda/recipes/rapids-xgboost/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - cudatoolkit ={{ cuda_version }}.*
     - nccl {{ nccl_version }}
     - python
-    - xgboost {{ xgboost_version }}
+    - xgboost {{ xgboost_version }}{{ minor_version }}
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -8,7 +8,8 @@ dask_xgboost_version:
 
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
-  - '=1.3.0dev.rapidsai0.17'
+  # Minor version is appended in meta.yaml
+  - '=1.3.0dev.rapidsai'
 
 # Versions for conda
 conda_version:


### PR DESCRIPTION
Because xgboost requires RMM, it's tied to a specific version of RAPIDS. We need to dynamically switch the version of xgboost based on the version of RAPIDS.

I think this will fix the conda solver issues for building v0.18