### PR TITLE
[REVIEW] FIX Replace ls with grep when searching for packages to upload

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -97,13 +97,13 @@ function upload_builds {
   else
     gpuci_logger "Upload key found, starting upload..."
     gpuci_logger "Files to upload..."
-    ls /conda/conda-bld/linux-64/rapids*.tar.bz2
-    ls /conda/conda-bld/linux-64/blazingsql*.tar.bz2
+    ls /conda/conda-bld/linux-64/* | grep -i rapids.*.tar.bz2
+    ls /conda/conda-bld/linux-64/* | grep -i blazingsql.*.tar.bz2
 
     gpuci_logger "Starting upload..."
-    ls /conda/conda-bld/linux-64/rapids*.tar.bz2 | xargs gpuci_retry \
+    ls /conda/conda-bld/linux-64/* | grep -i rapids.*.tar.bz2 | xargs gpuci_retry \
       anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai-nightly} --label main --skip-existing
-    ls /conda/conda-bld/linux-64/blazingsql*.tar.bz2 | xargs gpuci_retry \
+    ls /conda/conda-bld/linux-64/* | grep -i blazingsql.*.tar.bz2 | xargs gpuci_retry \
       anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai-nightly} --label main --skip-existing
   fi
 }

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -101,10 +101,14 @@ function upload_builds {
     ls /conda/conda-bld/linux-64/* | grep -i blazingsql.*.tar.bz2
 
     gpuci_logger "Starting upload..."
-    ls /conda/conda-bld/linux-64/* | grep -i rapids.*.tar.bz2 | xargs gpuci_retry \
-      anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai-nightly} --label main --skip-existing
-    ls /conda/conda-bld/linux-64/* | grep -i blazingsql.*.tar.bz2 | xargs gpuci_retry \
-      anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai-nightly} --label main --skip-existing
+    if [[ -n $(ls /conda/conda-bld/linux-64/* | grep -i rapids.*.tar.bz2) ]]; then
+      ls /conda/conda-bld/linux-64/* | grep -i rapids.*.tar.bz2 | xargs gpuci_retry \
+        anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai-nightly} --label main --skip-existing
+    fi
+    if [[ -n $(ls /conda/conda-bld/linux-64/* | grep -i blazingsql.*.tar.bz2) ]]; then
+      ls /conda/conda-bld/linux-64/* | grep -i blazingsql.*.tar.bz2 | xargs gpuci_retry \
+        anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai-nightly} --label main --skip-existing
+    fi
   fi
 }
 


### PR DESCRIPTION
Fixes the `ls` command erroring when no blazing packages are found. This moves the searching to `grep` so that finding nothing results in an empty string as opposed to erroring completely.

Test Output:

```
(base) dcullinan@dgx06:~/rapids/integration/ci/cpu$ ls test/*
test/blazingsql-build-env.tar.bz2  test/rapids-blazing.tar.bz2
(base) dcullinan@dgx06:~/rapids/integration/ci/cpu$ ls test/* | grep -i blazingsql.*.tar.bz2 | xargs echo
test/blazingsql-build-env.tar.bz2
(base) dcullinan@dgx06:~/rapids/integration/ci/cpu$ ls test/* | grep -i rapids.*.tar.bz2 | xargs echo
test/rapids-blazing.tar.bz2

(base) dcullinan@dgx06:~/rapids/integration/ci/cpu$ if [[ -n $(ls test/* | grep -i rapids.*.tar.bz2) ]]; then echo "test"; fi
test
(base) dcullinan@dgx06:~/rapids/integration/ci/cpu$ if [[ -n $(ls test/* | grep -i blazingsql.*.tar.bz2) ]]; then echo "test"; fi
test
(base) dcullinan@dgx06:~/rapids/integration/ci/cpu$ if [[ -n $(ls test/* | grep -i FileThatDoesntExist.*.tar.bz2) ]]; then echo "test"; fi
(base) dcullinan@dgx06:~/rapids/integration/ci/cpu$
```