### PR TITLE
[REVIEW] FIX Use if statement to avoid silent error

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -97,8 +97,12 @@ function upload_builds {
   else
     gpuci_logger "Upload key found, starting upload..."
     gpuci_logger "Files to upload..."
-    ls /conda/conda-bld/linux-64/* | grep -i rapids.*.tar.bz2
-    ls /conda/conda-bld/linux-64/* | grep -i blazingsql.*.tar.bz2
+    if [[ -n $(ls /conda/conda-bld/linux-64/* | grep -i rapids.*.tar.bz2) ]]; then
+      ls /conda/conda-bld/linux-64/* | grep -i rapids.*.tar.bz2
+    fi
+    if [[ -n $(ls /conda/conda-bld/linux-64/* | grep -i blazingsql.*.tar.bz2) ]]; then
+      ls /conda/conda-bld/linux-64/* | grep -i blazingsql.*.tar.bz2
+    fi
 
     gpuci_logger "Starting upload..."
     if [[ -n $(ls /conda/conda-bld/linux-64/* | grep -i rapids.*.tar.bz2) ]]; then


### PR DESCRIPTION
Test Output: 
```
(base) dcullinan@dgx06:~/rapids/integration/ci/cpu$ if [[ -n $(ls test/* | grep -i rapids.*.tar.bz2) ]]; then ls test/* | grep -i rapids.*.tar.bz2; fi
test/rapids-blazing.tar.bz2
(base) dcullinan@dgx06:~/rapids/integration/ci/cpu$ if [[ -n $(ls test/* | grep -i FileThatDoesntExist.*.tar.bz2) ]]; then ls test/* | grep -i FileThatDoesntExist.*.tar.bz2; fi
(base) dcullinan@dgx06:~/rapids/integration/ci/cpu$ echo $?
0
```