### PR TITLE
[REVIEW] FIX Call nvidia-smi before test

### DIFF
--- a/ci/test/cudf.sh
+++ b/ci/test/cudf.sh
@@ -9,6 +9,7 @@ export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids
 env
+nvidia-smi
 conda list
 
 TESTRESULTS_DIR=${WORKSPACE}/testresults

--- a/ci/test/cugraph.sh
+++ b/ci/test/cugraph.sh
@@ -15,6 +15,7 @@ export RAPIDS_DATASET_ROOT_DIR=/rapids/cugraph/datasets
 
 # Show environment
 env
+nvidia-smi
 conda list
 
 TESTRESULTS_DIR=${WORKSPACE}/testresults

--- a/ci/test/cuml.sh
+++ b/ci/test/cuml.sh
@@ -8,6 +8,7 @@ export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids
 env
+nvidia-smi
 conda list
 
 TESTRESULTS_DIR=${WORKSPACE}/testresults

--- a/ci/test/cuspatial.sh
+++ b/ci/test/cuspatial.sh
@@ -8,6 +8,7 @@ export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids
 env
+nvidia-smi
 conda list
 
 TESTRESULTS_DIR=${WORKSPACE}/testresults

--- a/ci/test/daskcuda.sh
+++ b/ci/test/daskcuda.sh
@@ -9,6 +9,7 @@ export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local
 source /opt/conda/bin/activate rapids
 
 env
+nvidia-smi
 conda list
 
 TESTRESULTS_DIR=${WORKSPACE}/testresults

--- a/ci/test/integration.sh
+++ b/ci/test/integration.sh
@@ -9,6 +9,7 @@ conda activate rapids
 
 gpuci_logger "Show env and current conda list"
 env
+nvidia-smi
 conda list
 
 export TESTRESULTS_DIR=${WORKSPACE}/testresults

--- a/ci/test/notebooks.sh
+++ b/ci/test/notebooks.sh
@@ -21,6 +21,9 @@ esac
 
 
 env
+nvidia-smi
+conda list
+
 /test.sh 2>&1 | tee nbtest.log
 EXITCODE=$?
 python /rapids/utils/nbtestlog2junitxml.py nbtest.log

--- a/ci/test/rmm.sh
+++ b/ci/test/rmm.sh
@@ -6,6 +6,7 @@ export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local
 # FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids
 env
+nvidia-smi
 conda list
 
 TESTRESULTS_DIR=${WORKSPACE}/testresults


### PR DESCRIPTION
Ensures nvidia-smi is called before tests are run for informational purposes.