### PR TITLE
ENH Allow blazing meta pkgs to fail

### DIFF
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -7,7 +7,6 @@ CONDA_CONFIG_FILE:
 # Use M.X.Ya (major.minor.patch) with 'a' version to match nightly tag
 RAPIDS_VER:
   - 0.17.0a
-  - 0.18.0a
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -7,7 +7,6 @@ CONDA_CONFIG_FILE:
 # Use M.X.Y (major.minor.patch) version to match tag
 RAPIDS_VER:
   - 0.17.0
-  - 0.18.0
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -7,7 +7,6 @@ DOCKER_REPO:
 # Use M.X (major.minor) version
 RAPIDS_VER:
   - 0.17
-  - 0.18
 
 CUDA_VER:
   - 11.0

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -120,7 +120,9 @@ if [[ "$BUILD_PKGS" == "meta" || -z "$BUILD_PKGS" ]] ; then
   # Run builds for meta-pkgs
   run_builds $CONDA_XGBOOST_RECIPE
   run_builds $CONDA_RAPIDS_RECIPE
+  set +e
   run_builds $CONDA_RAPIDS_BLAZING_RECIPE
+  set -e
 fi
 
 if [[ "$BUILD_PKGS" == "env" || -z "$BUILD_PKGS" ]] ; then


### PR DESCRIPTION
This will allow uploads to continue for now while we get blazing meta pkgs setup for v0.18

Also removes 0.18 from axis now that code freeze has happened and there is a separate `branch-0.18`