### PR TITLE
Enable parallelism in cudf & dask-cudf pytests

### DIFF
--- a/ci/test/cudf.sh
+++ b/ci/test/cudf.sh
@@ -50,7 +50,7 @@ if (( ${exitcode} != 0 )); then
 fi
 
 cd /rapids/cudf/python/custreamz
-py.test --junitxml=${TESTRESULTS_DIR}/pytest-custreamz.xml -v
+py.test -n 6 --junitxml=${TESTRESULTS_DIR}/pytest-custreamz.xml -v
 exitcode=$?
 if (( ${exitcode} != 0 )); then
    SUITEERROR=${exitcode}

--- a/ci/test/cudf.sh
+++ b/ci/test/cudf.sh
@@ -34,7 +34,7 @@ export PYTHONPATH=\
 ${PYTHONPATH}
 
 cd /rapids/cudf/python/cudf
-py.test --junitxml=${TESTRESULTS_DIR}/pytest-cudf.xml -v
+py.test -n 6 --junitxml=${TESTRESULTS_DIR}/pytest-cudf.xml -v
 exitcode=$?
 if (( ${exitcode} != 0 )); then
    SUITEERROR=${exitcode}
@@ -42,7 +42,7 @@ if (( ${exitcode} != 0 )); then
 fi
 
 cd /rapids/cudf/python/dask_cudf
-py.test --junitxml=${TESTRESULTS_DIR}/pytest-dask-cudf.xml -v
+py.test -n 6 --junitxml=${TESTRESULTS_DIR}/pytest-dask-cudf.xml -v
 exitcode=$?
 if (( ${exitcode} != 0 )); then
    SUITEERROR=${exitcode}

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -116,6 +116,7 @@ requirements:
     - pytest-benchmark
     - pytest-cov
     - pytest-timeout
+    - pytest-xdist
     - python
     - python-confluent-kafka {{ python_confluent_kafka_version }}
     - python-louvain


### PR DESCRIPTION
This PR enables pytest-xdist in cudf and dask-cudf pytests.