### PR TITLE
Revert "ENH Open gcc pinning to allow for new conda-forge gcc 9.3 pkgs"

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -21,7 +21,7 @@ conda_verify_version:
 
 # Versions for `libgcc-ng`, `libgfortran-ng`, `libstdcxx-ng` stack
 build_stack_version:
-  - '>=7.5.0'
+  - '=7.5.0'
 
 # Shared versions across meta-pkgs
 arrow_version:


### PR DESCRIPTION
Reverts rapidsai/integration#199

Due to excessive solve times experienced by cudf gpu tests, reverting this to try and unblock them