### PR TITLE
Upgrade to Treelite 1.0.0rc1

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -137,4 +137,4 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=0.93'
+  - '=1.0.0rc1'

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -21,7 +21,7 @@ conda_verify_version:
 
 # Versions for `libgcc-ng`, `libgfortran-ng`, `libstdcxx-ng` stack
 build_stack_version:
-  - '=7.5.0'
+  - '=9.3.0'
 
 # Shared versions across meta-pkgs
 arrow_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -21,7 +21,7 @@ conda_verify_version:
 
 # Versions for `libgcc-ng`, `libgfortran-ng`, `libstdcxx-ng` stack
 build_stack_version:
-  - '=9.3.0'
+  - '=7.5.0'
 
 # Shared versions across meta-pkgs
 arrow_version:


### PR DESCRIPTION
Required by rapidsai/cuml#3316, which needs the 1.0.0 version of the Treelite package.

For now the RC1 version is used; once the testing is complete with rapidsai/cuml#3316, I will release the 1.0.0 version.