### PR TITLE
upgrade build stack to 9.3.0

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -21,7 +21,7 @@ conda_verify_version:
 
 # Versions for `libgcc-ng`, `libgfortran-ng`, `libstdcxx-ng` stack
 build_stack_version:
-  - '=7.5.0'
+  - '=9.3.0'
 
 # Shared versions across meta-pkgs
 arrow_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -129,7 +129,7 @@ s3fs_version:
 scikit_learn_version:
   - '=0.23.1'
 scipy_version:
-  - '=1.5.1'
+  - '=1.5.3'
 setuptools_version:
   - '>=49,<50'
 spdlog_version:


### PR DESCRIPTION
PR to test upgrading the build stack to 9.3.0

- [x] rmm
- [x] cudf
- [x] cuml
- [x] cugraph
- [x] cuspatial
- [x] clx
- [x] cusignal
- [x] raft
- [x] dask-cuda
- [x] ucx-py
- [x] cuxfilter