### PR TITLE
Pin gdal to 3.1.x

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -69,7 +69,7 @@ flatbuffers_version:
 fsspec_version:
   - '>=0.6.0'
 gdal_version:
-  - '>=3.0.2,<3.1.0a0'
+  - '>=3.1.0,<3.2.0a0'
 geopandas_version:
   - '>=0.6, <=0.8.1'
 google_cloud_cpp_version:


### PR DESCRIPTION
Bump gdal from 3.0.x to 3.1.x, needed for https://github.com/rapidsai/cuspatial/pull/339.