### PR TITLE
Allow CuPy 9

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -43,7 +43,7 @@ cmake_format_version:
 cmake_setuptools_version:
   - '>=0.1.3'
 cupy_version:
-  - '>7.1.0,<9.0.0a0'
+  - '>7.1.0,<10.0.0a0'
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:


### PR DESCRIPTION
Relax the CuPy version constraint to allow CuPy 9 to be used as well.