### PR TITLE
Add moto min_version at 1.3.14, update s3fs to 0.5.2

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -93,7 +93,7 @@ requirements:
     - lightgbm
     - make
     - mimesis
-    - moto
+    - moto {{ moto_version }}
     - mypy {{ mypy_version }}
     - nccl {{ nccl_version }}
     - networkx {{ networkx_version }}
@@ -124,7 +124,7 @@ requirements:
     - rapidjson {{ rapidjson_version }}
     - rapids-pytest-benchmark
     - ripgrep
-    - s3fs
+    - s3fs {{ s3fs_version }}
     - setuptools
     - scikit-learn {{ scikit_learn_version }}
     - scipy {{ scipy_version }}

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - networkx {{ networkx_version }}
     - nodejs {{ nodejs_version }}
     - pytest
-    - s3fs
+    - s3fs {{ s3fs_version }}
     - scikit-learn {{ scikit_learn_version }}
     - scipy {{ scipy_version }}
     - seaborn

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -86,6 +86,8 @@ jupyterlab_version:
   - '=2.1'
 librdkafka_version:
   - '=1.5.*'
+moto_version:
+  - '>=1.3.14'
 mypy_version:
   - '0.782'
 nccl_version:
@@ -125,7 +127,7 @@ pytest_asyncio_version:
 rapidjson_version:
   - '=1.1.0'
 s3fs_version:
-  - '>=0.5.1'
+  - '>=0.5.2'
 scikit_learn_version:
   - '=0.23.1'
 scipy_version:


### PR DESCRIPTION
Pr adds the following:
- Add minimum dependency for moto to `1.3.14` 
- Updates s3fs min version to `0.5.2`
- Enforce s3fs versioning in rapids-build and notebook environments

Required for (and tested on) rapidsai/cudf#7144