### PR TITLE
Upgrade to Treelite 1.0.0 stable

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -139,4 +139,4 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=1.0.0rc1'
+  - '=1.0.0'


### PR DESCRIPTION
The 1.0.0 stable version of Treelite is [virtually identical to the 1.0.0 RC1 version](https://github.com/dmlc/treelite/pull/246), so I don't expect any code to break. 