### PR TITLE
Update nodejs version spec

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -95,7 +95,7 @@ nccl_version:
 networkx_version:
   - '>=2.3'
 nodejs_version:
-  - '>=12'
+  - '>=12,<15'
 numba_version:
   - '>=0.51.2'
 numpy_version:


### PR DESCRIPTION
Lately there have been a lot of conda errors regarding inconsistencies due to our NodeJS version (see screenshot/log below). It causes a lot of wasted time on CI jobs. This PR updates our version spec to not use Node v15. For reference, the latest LTS is 14 ([src](https://nodejs.org/en/)). Hopefully this helps the conda solve time/inconsistency.


**Log**: https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cugraph/job/prb/job/cugraph-gpu-test/CUDA=10.2,GPU_LABEL=gpu,OS=centos7,PYTHON=3.8/235/console

**Screenshot**:
![image](https://user-images.githubusercontent.com/7400326/107583980-b5586600-6bc9-11eb-80c9-fe2772d246b7.png)
