### PR TITLE
Bump xgboost to 1.3.3

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -9,7 +9,7 @@ dask_xgboost_version:
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
   # Minor version is appended in meta.yaml
-  - '=1.3.0dev.rapidsai'
+  - '=1.3.3dev.rapidsai'
 
 # Versions for conda
 conda_version:


### PR DESCRIPTION
Simply bump xgboost to the latest version

Should fix test failures in #213 