### PR TITLE
Set relative tolerance on test

### DIFF
--- a/test/cugraph/test_pagerank.py
+++ b/test/cugraph/test_pagerank.py
@@ -100,4 +100,4 @@ def test_pagerank() :
     assert len(expectedPageRanks) == len(gdf_page["pagerank"])
     for (actual, expected) in zip(gdf_page["pagerank"].to_pandas(),
                                   expectedPageRanks):
-        assert actual == pytest.approx(expected)
+        assert actual == pytest.approx(expected, rel=1e-3)


### PR DESCRIPTION
This isn't really a test to determine if pagerank is generating precise answers.  Rather it is a test to determine if the basic mechanics of importing cugraph and executing an algorithm works.  3 significant digits of accuracy seems sufficient for this style of test.