### PR TITLE
[REVIEW] ENH Add ninja to build environment

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -97,6 +97,7 @@ requirements:
     - mypy {{ mypy_version }}
     - nccl {{ nccl_version }}
     - networkx {{ networkx_version }}
+    - ninja
     - nltk
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}


### PR DESCRIPTION
Adds `ninja` to rapids-build-env meta package. This package will be used to speed up builds and enable `ccache` to integrate with `conda build`.