### PR TITLE
[REVIEW] Upgrade pandas to 1.2.2

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -105,7 +105,7 @@ nvtx_version:
 openjdk_version:
   - '>=8.0'
 pandas_version:
-  - '>=1.0,<1.2.0dev0'
+  - '>=1.0,<1.3.0dev0'
 pandoc_version:
   - '<=2.0.0'
 panel_version:


### PR DESCRIPTION
This version change is needed as part of the pandas upgrade happening in cudf: https://github.com/rapidsai/cudf/pull/7375/