### PR TITLE
Update nccl to 2.8.4.1

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -91,7 +91,7 @@ moto_version:
 mypy_version:
   - '0.782'
 nccl_version:
-  - '>=2.7.8.1,<3.0a0'
+  - '>=2.8.4.1,<3.0a0'
 networkx_version:
   - '>=2.3'
 nodejs_version:


### PR DESCRIPTION
This should resolve the conflicts in https://github.com/rapidsai/cugraph/pull/1445

Since all of our libraries use a `nccl >= 2.5` (at least), this change should be fine.