### PR TITLE
bump cupy version to >=8.5.0

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -43,7 +43,7 @@ cmake_format_version:
 cmake_setuptools_version:
   - '>=0.1.3'
 cupy_version:
-  - '>=7.8.0,<9.0.0a0'
+  - '>=8.5.0,<9.0.0a0'
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:


### PR DESCRIPTION
Related to rapidsai/cudf#7615 to unblock Dask bugs that are fixed in cupy 8.5.0