### PR TITLE
Update minimum scipy version to 1.6

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -133,7 +133,7 @@ scikit_image_version:
 scikit_learn_version:
   - '=0.23.1'
 scipy_version:
-  - '=1.5.3'
+  - '=1.6.0'
 setuptools_version:
   - '>=49,<50'
 spdlog_version:


### PR DESCRIPTION
Could we please bump the minimum version of scipy to 1.6? cuSignal would like to run CI/CD against new features introduced in scipy signal.

CC @ajschmidt8 