### PR TITLE
ENH Add CUDA 11.2 support

### DIFF
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -10,6 +10,7 @@ RAPIDS_VER:
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
+  - 11.2
   - 11.0
   - 10.2
   - 10.1

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -10,6 +10,7 @@ RAPIDS_VER:
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
+  - 11.2
   - 11.0
   - 10.2
   - 10.1


### PR DESCRIPTION
Updating axis files to build meta/env packages for CUDA 11.2 in order to support CUDA 11.2 builds and testing.

This is related to work in rapidsai/gpuci-build-environment#167 to add CUDA 11.2 support to gpuCI images.
