### PR TITLE
Update pytorch version

### DIFF
--- a/ci/test/notebooks.sh
+++ b/ci/test/notebooks.sh
@@ -11,7 +11,7 @@ source /opt/conda/bin/activate rapids
 # to its size, but some notebooks still depend on it.
 case "${CUDA_VER}" in
 "10.1" | "10.2" | "11.0")
-    conda install -y -c pytorch "pytorch>=1.4"
+    conda install -y -c pytorch "pytorch=1.7"
     ;;
 *)
     echo "Unsupported CUDA version for pytorch."


### PR DESCRIPTION
This PR pins `pytorch` to version `1.7`. The reason this is being updated to `1.7` is because `1.7` supports CUDA 11.0 ([src](https://pytorch.org/blog/pytorch-1.7-released/)) and `1.8` does not ([src](https://anaconda.org/pytorch/pytorch/files?version=1.8.0)).