### PR TITLE
Bump dask version to 2021.3.1

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -47,7 +47,7 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '>=2.23.0'
+  - '>=2021.3.1'
 datashader_version:
   - '>=0.11.1,<0.12'
 distributed_version:


### PR DESCRIPTION
Update dask version to `2021.3.1` as a part of work in rapidsai/cudf#7740