### PR TITLE
[REVIEW] TST Temporarily use core images for nightly testing

### DIFF
--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -2,7 +2,7 @@ RUNTIME_DOCKER_REPO:
   - rapidsai/rapidsai-nightly
 
 DOCKER_REPO:
-  - rapidsai/rapidsai-dev-nightly
+  - rapidsai/rapidsai-core-dev-nightly
 
 # Use M.X (major.minor) version
 RAPIDS_VER:


### PR DESCRIPTION
This is a temporary change that should be reverted when https://github.com/rapidsai/integration/pull/237 is merged and `rapidsai` images are being successfully built.

This sets core images to be tested by our nightly tests for now. Nightly tests have been blocked and this change will guarantee to get us some feedback on image testing for code-freeze.