### PR TITLE
Remove `rapids-pytest-benchmark` dependency

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -126,7 +126,6 @@ requirements:
     - python-confluent-kafka {{ python_confluent_kafka_version }}
     - python-louvain
     - rapidjson {{ rapidjson_version }}
-    - rapids-pytest-benchmark
     - ripgrep
     - s3fs {{ s3fs_version }}
     - setuptools


### PR DESCRIPTION
Since `rapids-pytest-benchmark` now depends on `rmm`, this pollutes the `gpuci/rapidsai` images with an install of RMM on the same image we need to build RMM.

Jobs/repos that require this package for benchmarks will need to manually install install it instead of relying on `rapids-build-env` to incude it.