### PR TITLE
Upgrade to Treelite 1.1.0

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -141,4 +141,4 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=1.0.0'
+  - '=1.1.0'


### PR DESCRIPTION
Required by rapidsai/cuml#3708. See the CI result in rapidsai/cuml#3708 which is testing cuML with Treelite 1.1.0.