### PR TITLE
Updated NetworkX version to 2.5.1

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -93,7 +93,7 @@ mypy_version:
 nccl_version:
   - '>=2.8.4.1,<3.0a0'
 networkx_version:
-  - '>=2.3'
+  - '>=2.5.1'
 nodejs_version:
   - '>=12,<15'
 numba_version:


### PR DESCRIPTION
Updated NetworkX version to the latest (2.5.1), which addresses an incompatibility with the latest `decorator` dependency.

Tested by running the cuGraph BC tests which were previously failing with Nx 2.5 in the old cuGraph dev environment.

See also: https://github.com/rapidsai/cugraph/pull/1510

NOTE: I *have not* tested this particular environment file, just the corresponding change in the PR linked above.