### PR TITLE
Set minimum version for `gcsfs`

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -71,7 +71,7 @@ requirements:
     - flake8 {{ flake8_version }}
     - flatbuffers {{ flatbuffers_version }}
     - fsspec {{ fsspec_version }}
-    - gcsfs
+    - gcsfs {{ gcsfs_version }}
     - gdal {{ gdal_version }}
     - geopandas {{ geopandas_version }}
     - git

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -67,11 +67,13 @@ flake8_version:
 flatbuffers_version:
   - '=1.10.0'
 fsspec_version:
-  - '>=0.6.0'
+  - '>=0.9.0'
 gdal_version:
   - '>=3.2.0,<3.3.0a0'
 geopandas_version:
   - '>=0.6, <=0.8.1'
+gcsfs_version:
+  - '>=0.8.0'
 google_cloud_cpp_version:
   - '=1.16.0'
 gmock_version:


### PR DESCRIPTION
Bumping up the `fsspec` version to `0.9.0` and `gcsfs` to `0.8.0` as CI seems to be fetching older version of `gcsfs`