### PR TITLE
Add ccache to the rapids-build-env meta package

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -47,6 +47,7 @@ requirements:
     - boost-cpp {{ boost_cpp_version }}
     - boto3
     - cachetools
+    - ccache {{ ccache_version }}
     - conda-forge::clang {{ clang_version }}
     - conda-forge::clang-tools {{ clang_version }}
     - cmake {{ cmake_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -34,6 +34,8 @@ bokeh_version:
   - '>=2.1.1,<=2.2.3'
 boost_cpp_version:
   - '=1.72.0'
+ccache_version:
+  - '=4.1'
 clang_version:
   - '=8.0.1'
 cmake_version:


### PR DESCRIPTION
Since I didn't find a `branch-0.20` where I could send a PR for this, I'm using 0.19 instead.