### PR TITLE
[REVIEW] FIX Add nlohmann json dep for Blazing

### DIFF
--- a/conda/recipes/blazingsql-build-env/meta.yaml
+++ b/conda/recipes/blazingsql-build-env/meta.yaml
@@ -43,6 +43,7 @@ requirements:
         - jpype1
         - maven
         - netifaces
+        - nlohmann_json
         - ninja
         - openjdk {{ openjdk_version }}
         - pyhive


### PR DESCRIPTION
Adds the `nlohmann_json` dependency to blazingdb build env to match their recent PR: https://github.com/BlazingDB/blazingsql/pull/1430