### PR TITLE
Update nightly axis

### DIFF
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -23,3 +23,9 @@ DEFAULT_CUDA_VER:
 PYTHON_VER:
   - 3.7
   - 3.8
+
+exclude:
+  - RAPIDS_VER: 0.20.0a
+    CUDA_VER: 10.1
+  - RAPIDS_VER: 0.20.0a
+    CUDA_VER: 10.2


### PR DESCRIPTION
This PR updates the nightly axis to exclude tests for RAPIDS_VER 20 and CUDA 10.x. This is because RAPIDS v0.20 drops support for CUDA 10.x.