### PR TITLE
Update Numba version to >=0.53.1

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -103,7 +103,7 @@ nlohmann_json_version:
 nodejs_version:
   - '>=12,<15'
 numba_version:
-  - '>=0.51.2'
+  - '>=0.53.1'
 numpy_version:
   - '>=1.17.3'
 nvtx_version:


### PR DESCRIPTION
Needed for https://github.com/rapidsai/cudf/pull/8017

**NOTE**: This is for 0.20, not 0.19.