### PR TITLE
Add pydocstyle to environment.

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -112,6 +112,7 @@ requirements:
     - psutil
     - pyarrow {{ arrow_version }}
     - pydeck {{ pydeck_version }}
+    - pydocstyle {{ pydocstyle_version }}
     - pynvml
     - pyorc
     - pyppeteer {{ pyppeteer_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -118,6 +118,8 @@ panel_version:
   - '>=0.10.3'
 pydeck_version:
   - '>=0.3, <=0.5.0'
+pydocstyle_version:
+  - '>=6.0.0, <=7.0.0'
 python_confluent_kafka_version:
   - '>=1.3.0'
 pytorch_version:


### PR DESCRIPTION
This PR adds `pydocstyle` to the rapids build environment so that we can start statically linting our docstrings. We plan to incrementally apply this styling in `cudf`, but `pydocstyle` is the standard so as other packages move in this direction `pydocstyle` is the tool they'll want as well. The package follows semantic versioning, so in the interest of CI not suddenly failing when a new version is released with modifications to any rules I've constrained the package versions accordingly.