### PR TITLE
Allow blazing builds to fail pipeline

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -99,9 +99,7 @@ if [[ "$BUILD_PKGS" == "meta" || -z "$BUILD_PKGS" ]] ; then
   # Run builds for meta-pkgs
   run_builds $CONDA_XGBOOST_RECIPE
   run_builds $CONDA_RAPIDS_RECIPE
-  set +e
   run_builds $CONDA_RAPIDS_BLAZING_RECIPE
-  set -e
 fi
 
 if [[ "$BUILD_PKGS" == "env" || -z "$BUILD_PKGS" ]] ; then


### PR DESCRIPTION
This PR undoes the temporary changes from #187 which prevented failing `blazing` builds from failing the CI pipeline.