### PR TITLE
Update jupyterlab version

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -85,7 +85,7 @@ ipython_version:
 isort_version:
   - '=5.0'
 jupyterlab_version:
-  - '=2.1'
+  - '>=3.0.0,<4.0a0'
 librdkafka_version:
   - '=1.5.*'
 moto_version:


### PR DESCRIPTION
This PR updates the version of Jupyterlab used in our packages in order to support https://github.com/rapidsai/jupyterlab-nvdashboard/pull/85.