### PR TITLE
Bump CMake version to 3.20.1

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -37,7 +37,7 @@ boost_cpp_version:
 clang_version:
   - '=8.0.1'
 cmake_version:
-  - '=3.20.1'
+  - '>=3.20.1,<3.21'
 cmake_format_version:
   - '=0.6.11'
 cmake_setuptools_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -37,7 +37,7 @@ boost_cpp_version:
 clang_version:
   - '=8.0.1'
 cmake_version:
-  - '=3.18'
+  - '=3.20.1'
 cmake_format_version:
   - '=0.6.11'
 cmake_setuptools_version:


### PR DESCRIPTION
Bring in CMake version which will facilitate transition to rapids-cmake and eliminate a variety of bugs related to CUDA, ccache, and compiler detection