### PR TITLE
Add JupyterLab 3 Dependencies

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -125,7 +125,6 @@ requirements:
     - pytest-timeout
     - pytest-xdist
     - python
-    - python-build
     - python-confluent-kafka {{ python_confluent_kafka_version }}
     - python-louvain
     - rapidjson {{ rapidjson_version }}

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -125,6 +125,7 @@ requirements:
     - pytest-timeout
     - pytest-xdist
     - python
+    - python-build
     - python-confluent-kafka {{ python_confluent_kafka_version }}
     - python-louvain
     - rapidjson {{ rapidjson_version }}

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -57,6 +57,7 @@ requirements:
     - nodejs {{ nodejs_version }}
     - openslide
     - pytest
+    - python-build
     - s3fs {{ s3fs_version }}
     - scikit-image {{ scikit_image_version }}
     - scikit-learn {{ scikit_learn_version }}

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -48,6 +48,7 @@ requirements:
     - filterpy
     - holoviews
     - ipython {{ ipython_version }}
+    - ipywidgets
     - jupyter-server-proxy
     - jupyterlab {{ jupyterlab_version }}
     - jupyterlab-nvdashboard

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -50,6 +50,8 @@ requirements:
     - ipython {{ ipython_version }}
     - jupyter-server-proxy
     - jupyterlab {{ jupyterlab_version }}
+    - jupyterlab-nvdashboard
+    - jupyterlab_widgets
     - matplotlib-base
     - networkx {{ networkx_version }}
     - nodejs {{ nodejs_version }}


### PR DESCRIPTION
This PR adds a few dependencies to our packages following the upgrade to JupyterLab 3 in #261 and https://github.com/rapidsai/jupyterlab-nvdashboard/pull/85.

The `python-build` package is now needed to build the `nvdashboard` extension.

Additionally, the dependencies listed [here](https://github.com/rapidsai/docker/blob/f23d1f18dd79639eaad3dc580fa946997f8e1524/templates/rapidsai-core/partials/install_notebooks.dockerfile.j2#L10-L15) can now be installed solely via `conda` and no longer need the `jupyter labextension install` counterpart.