### PR TITLE
Remove python-build dependency

### DIFF
--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -58,7 +58,6 @@ requirements:
     - nodejs {{ nodejs_version }}
     - openslide
     - pytest
-    - python-build
     - s3fs {{ s3fs_version }}
     - scikit-image {{ scikit_image_version }}
     - scikit-learn {{ scikit_learn_version }}


### PR DESCRIPTION
This PR removes the `python-build` dependency that was added in #266. It is no longer needed for the `jupyterlab-nvdashboard` repo after switching from using `python -m build` to `python setup.py sdist bdist_wheel` to build and package the extension in https://github.com/rapidsai/jupyterlab-nvdashboard/pull/95.