### PR TITLE
Switch integration to calver

### DIFF
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -6,7 +6,11 @@ CONDA_CONFIG_FILE:
 
 # Use M.X.Ya (major.minor.patch) with 'a' version to match nightly tag
 RAPIDS_VER:
-  - 0.20.0a
+  - 21.06.00a
+
+# Use M.X (major.minor)
+BLAZING_VER:
+  - '0.20'
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -6,7 +6,11 @@ CONDA_CONFIG_FILE:
 
 # Use M.X.Y (major.minor.patch) version to match tag
 RAPIDS_VER:
-  - '0.20.0'
+  - '21.06.00'
+
+# Use M.X (major.minor)
+BLAZING_VER:
+  - '0.20'
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -6,7 +6,7 @@ DOCKER_REPO:
 
 # Use M.X (major.minor) version
 RAPIDS_VER:
-  - '0.20'
+  - '21.06'
 
 CUDA_VER:
   - 11.2

--- a/conda/recipes/rapids-blazing/meta.yaml
+++ b/conda/recipes/rapids-blazing/meta.yaml
@@ -1,5 +1,6 @@
 {% set rapids_version = environ.get('RAPIDS_VER', '0.0.0') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version = rapids_version.split('.')[0] + '.' + rapids_version.split('.')[1] %}
+{% set blazing_version = environ.get('BLAZING_VER', '0.0.0') %}
 {% set cuda_version = '.'.join(environ.get('CUDA_VERSION', '10.0').split('.')[:2]) %}
 {% set py_version = environ.get('CONDA_PY', 36) %}
 
@@ -27,6 +28,7 @@ build:
   script_env:
     - CUDA_VERSION
     - RAPIDS_VER
+    - BLAZING_VER
     - VERSION_SUFFIX
 
 requirements:
@@ -35,7 +37,7 @@ requirements:
   run:
     - cudatoolkit ={{ cuda_version }}.*
     - rapids ={{ minor_version }}.*
-    - blazingsql ={{ minor_version }}.*
+    - blazingsql ={{ blazing_version }}.*
 
 test:
   requires:


### PR DESCRIPTION
Do not merge before Friday 5/14!

1) Switches all `0.20` references to `21.06`
2) Adds an axis to tie a BlazingSQL version to a RAPIDS version