### PR TITLE
Upgrade to Treelite 1.3.0

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -149,4 +149,4 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=1.1.0'
+  - '=1.3.0'


### PR DESCRIPTION
Required by rapidsai/cuml#3855. See the CI result in rapidsai/cuml#3855 which is testing cuML with Treelite 1.3.0.