### PR TITLE
Bump geopandas version to match cuspatial requirements.

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -71,7 +71,7 @@ fsspec_version:
 gdal_version:
   - '>=3.2.0,<3.3.0a0'
 geopandas_version:
-  - '>=0.9.0'
+  - '>=0.9.0,<0.10.0a0'
 gcsfs_version:
   - '>=0.8.0'
 google_cloud_cpp_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -71,7 +71,7 @@ fsspec_version:
 gdal_version:
   - '>=3.2.0,<3.3.0a0'
 geopandas_version:
-  - '>=0.6, <=0.8.1'
+  - '>=0.9.0'
 gcsfs_version:
   - '>=0.8.0'
 google_cloud_cpp_version:


### PR DESCRIPTION
Geopandas is 0.9.0+ in cuspatial, now.