### PR TITLE
Temporarily remove cucim from rapids meta-package [skip ci]

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - cudf ={{ minor_version }}.*
     - cugraph ={{ minor_version }}.*
     - cuml ={{ minor_version }}.*
-    - cucim ={{ minor_version }}.*
+    # - cucim ={{ minor_version }}.*
     - cusignal ={{ minor_version }}.*
     - cuspatial ={{ minor_version }}.*
     - custreamz ={{ minor_version }}.*


### PR DESCRIPTION
This PR temporarily removes `cucim` from the `rapids` meta-package since it's causing build issues and we need to get `21.06` packages out to unblock the rest of RAPIDS.