### PR TITLE
Revert BlazingSQL Calver Changes

### DIFF
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -8,10 +8,6 @@ CONDA_CONFIG_FILE:
 RAPIDS_VER:
   - 21.06.00a
 
-# Use M.X (major.minor)
-BLAZING_VER:
-  - '0.20'
-
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
   - 11.2

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -6,11 +6,7 @@ CONDA_CONFIG_FILE:
 
 # Use M.X.Y (major.minor.patch) version to match tag
 RAPIDS_VER:
-  - '21.06.00'
-
-# Use M.X (major.minor)
-BLAZING_VER:
-  - '0.20'
+  - "21.06.00"
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/conda/recipes/rapids-blazing/meta.yaml
+++ b/conda/recipes/rapids-blazing/meta.yaml
@@ -1,6 +1,5 @@
 {% set rapids_version = environ.get('RAPIDS_VER', '0.0.0') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version = rapids_version.split('.')[0] + '.' + rapids_version.split('.')[1] %}
-{% set blazing_version = environ.get('BLAZING_VER', '0.0.0') %}
 {% set cuda_version = '.'.join(environ.get('CUDA_VERSION', '10.0').split('.')[:2]) %}
 {% set py_version = environ.get('CONDA_PY', 36) %}
 
@@ -28,7 +27,6 @@ build:
   script_env:
     - CUDA_VERSION
     - RAPIDS_VER
-    - BLAZING_VER
     - VERSION_SUFFIX
 
 requirements:
@@ -37,7 +35,7 @@ requirements:
   run:
     - cudatoolkit ={{ cuda_version }}.*
     - rapids ={{ minor_version }}.*
-    - blazingsql ={{ blazing_version }}.*
+    - blazingsql ={{ minor_version }}.*
 
 test:
   requires:


### PR DESCRIPTION
This PR reverts some of the `blazing` specific changes made in #269 since they'll now be switching to calver with us.