### PR TITLE
Add exclude to axes files

### DIFF
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -16,3 +16,5 @@ CUDA_VER:
 PYTHON_VER:
   - 3.7
   - 3.8
+
+exclude:

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -16,3 +16,5 @@ CUDA_VER:
 PYTHON_VER:
   - 3.7
   - 3.8
+
+exclude:

--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -21,3 +21,5 @@ LINUX_VER:
 
 PYTHON_VER:
   - 3.7
+
+exclude:


### PR DESCRIPTION
This PR re-adds the `exclude` keys to our axes files that seem to have been accidentally removed in some recent commits. It is necessary to keep them (even if they are blank) so that our Jenkins jobs work correctly.