### PR TITLE
Revert "Temporarily disable blazing builds"

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -86,11 +86,11 @@ function upload_builds {
     gpuci_logger "Starting upload..."
     if [[ -n $(ls /conda/conda-bld/linux-64/* | grep -i rapids.*.tar.bz2) ]]; then
       ls /conda/conda-bld/linux-64/* | grep -i rapids.*.tar.bz2 | xargs gpuci_retry \
-        anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai-nightly} --label main --skip-existing
+        anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai-nightly} --label main --skip-existing --no-progress
     fi
     if [[ -n $(ls /conda/conda-bld/linux-64/* | grep -i blazingsql.*.tar.bz2) ]]; then
       ls /conda/conda-bld/linux-64/* | grep -i blazingsql.*.tar.bz2 | xargs gpuci_retry \
-        anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai-nightly} --label main --skip-existing
+        anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai-nightly} --label main --skip-existing --no-progress
     fi
   fi
 }

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -99,9 +99,7 @@ if [[ "$BUILD_PKGS" == "meta" || -z "$BUILD_PKGS" ]] ; then
   # Run builds for meta-pkgs
   run_builds $CONDA_XGBOOST_RECIPE
   run_builds $CONDA_RAPIDS_RECIPE
-  set +e
   run_builds $CONDA_RAPIDS_BLAZING_RECIPE
-  set -e
 fi
 
 if [[ "$BUILD_PKGS" == "env" || -z "$BUILD_PKGS" ]] ; then


### PR DESCRIPTION
This PR reverts #276 since `rapids-blazing` now builds successfully again (see https://gpuci.gpuopenanalytics.com/job/rapidsai/job/integration/job/branches/job/branch-meta-pkg-nightly-build/982/).

It also. adds the `--no-progress` flag to our `conda` uploads.