### PR TITLE
Support Dask + Distributed 2021.05.1

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -47,11 +47,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '>=2021.4.0,<=2021.5.0'
+  - '>=2021.4.0,<=2021.5.1'
 datashader_version:
   - '>=0.11.1,<0.12'
 distributed_version:
-  - '>=2.23.0,<=2021.5.0'
+  - '>=2.23.0,<=2021.5.1'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:


### PR DESCRIPTION
Allow installing Dask + Distributed 2021.05.1 to be installed.

~~This isn't released yet, but this tees things up so we are ready to go once it comes out.~~

Used by PR ( https://github.com/rapidsai/cudf/pull/8392 )