### PR TITLE
Bump `isort` version to 5.6

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -83,7 +83,7 @@ gtest_version:
 ipython_version:
   - '=7.15'
 isort_version:
-  - '=5.0'
+  - '=5.6'
 jupyterlab_version:
   - '>=3.0.0,<4.0a0'
 jupyter_packaging_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -83,7 +83,7 @@ gtest_version:
 ipython_version:
   - '=7.15'
 isort_version:
-  - '=5.6'
+  - '=5.6.4'
 jupyterlab_version:
   - '>=3.0.0,<4.0a0'
 jupyter_packaging_version:


### PR DESCRIPTION
This change is intended for 21.08

[With `isort` 5.6.0 came the ability to resort .pxd files](https://pycqa.github.io/isort/CHANGELOG/#560-october-7-2020), in addition to .pyx. By bumping the version here, we could begin enforcing .pxd package sorting on RAPIDS projects with Cython code.

Also relevant to rapidsai/cudf#8215