### PR TITLE
[REVIEW] FIX Install rapids pytest benchmark

### DIFF
--- a/ci/test/cugraph.sh
+++ b/ci/test/cugraph.sh
@@ -18,6 +18,9 @@ env
 nvidia-smi
 conda list
 
+# Install pytest plugin for cugraph
+conda install rapids-pytest-benchmark
+
 TESTRESULTS_DIR="$WORKSPACE/testresults"
 mkdir -p ${TESTRESULTS_DIR}
 SUITEERROR=0


### PR DESCRIPTION
cuGraph pytests are dependent on this package to run properly, otherwise they run into the following error: 

```
10:51:23 ERROR: usage: py.test [options] [file_or_dir] [file_or_dir] [...]
10:51:23 py.test: error: unrecognized arguments: --benchmark-gpu-disable
```

We do not use these arguments in the script, but they are added programmatically via cugraph's `pytest.ini` script in their repo, seen here: https://github.com/rapidsai/cugraph/blob/branch-21.06/python/pytest.ini