### PR TITLE
[REVIEW] FIX Update cugraph test dir

### DIFF
--- a/ci/test/cugraph.sh
+++ b/ci/test/cugraph.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set +e
 set -x
-export HOME="$WORKSPACE"
-export LIBCUDF_KERNEL_CACHE_PATH="$WORKSPACE/.jitcache"
+export HOME="${WORKSPACE}"
+export LIBCUDF_KERNEL_CACHE_PATH="${WORKSPACE}/.jitcache"
 export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/local/gcc7/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # FIXME: "source activate" line should not be needed
@@ -18,12 +18,12 @@ env
 nvidia-smi
 conda list
 
-TESTRESULTS_DIR="$WORKSPACE/testresults"
+TESTRESULTS_DIR="${WORKSPACE}/testresults"
 mkdir -p ${TESTRESULTS_DIR}
 SUITEERROR=0
 
 # gtests
-for gt in /rapids/cugraph/cpp/build/gtests/*_TEST; do
+for gt in /rapids/cugraph/cpp/build/tests/*_TEST; do
    # FIXME: remove this ASAP
    ${gt} --gtest_output=xml:${TESTRESULTS_DIR}/
    exitcode=$?


### PR DESCRIPTION
Nightly tests are failing to find gtests for cuGraph. cuGraph compilation puts the GTests inside the `tests` dir now instead of `gtests`. This is confirmed by @ChuckHastings