### PR TITLE
Add `nbsphinx` version spec

### DIFF
--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - doxygen {{ doxygen_version }}
     - jupyter_sphinx
     - markdown
-    - nbsphinx
+    - nbsphinx {{ nbsphinx_version }}
     - numpydoc
     - pandoc {{ pandoc_version }}
     - recommonmark

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -96,6 +96,8 @@ mypy_version:
   - '0.782'
 mysql_connector_cpp_version:
   - '8.0.23'
+nbsphinx_version:
+  - '>=0.8.6'
 nccl_version:
   - '>=2.9.9,<3.0a0'
 networkx_version:


### PR DESCRIPTION
This PR adds a version specifier to the `nbsphinx` package. The version should be a minimum of `0.8.6` to fix the doc build issues described in https://github.com/rapidsai/cudf/issues/8345.