### PR TITLE
Ignore `raft` unit tests for `cugraph` [skip ci]

### DIFF
--- a/ci/test/cugraph.sh
+++ b/ci/test/cugraph.sh
@@ -34,7 +34,7 @@ for gt in /rapids/cugraph/cpp/build/tests/*_TEST; do
 done
 
 # Python tests
-py.test --junitxml=${TESTRESULTS_DIR}/pytest.xml -v /rapids/cugraph/python
+pytest --ignore=cugraph/raft --junitxml=${TESTRESULTS_DIR}/pytest.xml -v /rapids/cugraph/python
 exitcode=$?
 if (( ${exitcode} != 0 )); then
    SUITEERROR=${exitcode}


### PR DESCRIPTION
This PR adds a flag to ignore the `raft` unit tests in the `cugraph` repo since those tests are meant to be run from the `raft` repo itself (and not a downstream repo).