### PR TITLE
Update xgboost version

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -9,7 +9,7 @@ dask_xgboost_version:
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
   # Minor version is appended in meta.yaml
-  - '=1.4.0dev.rapidsai'
+  - '=1.4.2dev.rapidsai'
 
 # Versions for conda
 conda_version:


### PR DESCRIPTION
This PR updates the `xgboost` version to match `cuml`'s version ([link](https://github.com/rapidsai/cuml/blob/branch-21.08/ci/gpu/build.sh#L58)).