### PR TITLE
Limit clang dependency for x86_64

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -47,8 +47,8 @@ requirements:
     - boost-cpp {{ boost_cpp_version }}
     - boto3
     - cachetools
-    - conda-forge::clang {{ clang_version }}
-    - conda-forge::clang-tools {{ clang_version }}
+    - conda-forge::clang {{ clang_version }} # [x86_64]
+    - conda-forge::clang-tools {{ clang_version }} # [x86_64]
     - cmake {{ cmake_version }}
     - cmake-format {{ cmake_format_version }}
     - cmake_setuptools {{ cmake_setuptools_version }}


### PR DESCRIPTION
Clang is only used to check code format and format test will only be run on x86_64 (not arm64)