### PR TITLE
Remove `21.08` from axis [skip ci]

### DIFF
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -7,7 +7,6 @@ CONDA_CONFIG_FILE:
 # Use M.X.Ya (major.minor.patch) with 'a' version to match nightly tag
 RAPIDS_VER:
   - 21.06.00a
-  - 21.08.00a
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:


### PR DESCRIPTION
This PR removes `21.08.00.a` from the axis for `branch-21.06`