### PR TITLE
Add `html5lib` to `rapids-doc-env`

### DIFF
--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -36,6 +36,7 @@ requirements:
   run:
     - beautifulsoup4
     - doxygen {{ doxygen_version }}
+    - html5lib
     - jupyter_sphinx
     - markdown
     - nbsphinx {{ nbsphinx_version }}


### PR DESCRIPTION
This PR adds `html5lib` to the `rapids-doc-env` environment, which will be necessary for the changes introduced in https://github.com/rapidsai/docs/pull/194 that support the new `cudf` docs layout.