### PR TITLE
ENH Add update version script

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -14,7 +14,7 @@ NEXT_FULL_TAG=$1
 CURRENT_TAG=$(git tag --merged HEAD | grep -xE '^v.*' | sort --version-sort | tail -n 1 | tr -d 'v')
 CURRENT_MAJOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}')
 CURRENT_MINOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}')
-CURRENT_PATCH=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}')
+CURRENT_PATCH=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}' | tr -d 'a')
 CURRENT_SHORT_TAG=${CURRENT_MAJOR}.${CURRENT_MINOR}
 
 #Get <major>.<minor> for next version


### PR DESCRIPTION
Adds an update version script to the integration repo, which will add the new version to the axis files. This will be utilized during burndown.

Example output
```
bash ci/release/update-version.sh 21.10.00
```

```
diff --git a/ci/axis/nightly.yaml b/ci/axis/nightly.yaml
index e83070e..ad78e00 100644
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -6,6 +6,7 @@ CONDA_CONFIG_FILE:

 # Use M.X.Ya (major.minor.patch) with 'a' version to match nightly tag
 RAPIDS_VER:
+  - 21.10.00a
   - 21.08.00a

 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
diff --git a/ci/axis/release.yaml b/ci/axis/release.yaml
index eb33b5c..4dd43fb 100644
--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -6,6 +6,7 @@ CONDA_CONFIG_FILE:

 # Use M.X.Y (major.minor.patch) version to match tag
 RAPIDS_VER:
+  - "21.10.00"
   - "21.08.00"

 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
diff --git a/ci/axis/tests.yaml b/ci/axis/tests.yaml
index 3d31177..393713f 100644
--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -6,6 +6,7 @@ DOCKER_REPO:

 # Use M.X (major.minor) version
 RAPIDS_VER:
+  - "21.10"
   - "21.08"

 CUDA_VER:
(END)
```