### PR TITLE
[REVIEW] Upgrade arrow & librdkafka

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -25,7 +25,7 @@ build_stack_version:
 
 # Shared versions across meta-pkgs
 arrow_version:
-  - '=1.0.1'
+  - '=4.0.1'
 benchmark_version:
   - '=1.5.1'
 black_version:
@@ -89,7 +89,7 @@ jupyterlab_version:
 jupyter_packaging_version:
   - '>=0.7.0,<0.8'
 librdkafka_version:
-  - '=1.5.*'
+  - '=1.6.*'
 moto_version:
   - '>=1.3.14'
 mypy_version:


### PR DESCRIPTION
This PR bumps arrow version to `4.0.1` and we would also need `librdkafka` to be fetching latest versions of `1.6.x` as older versions bring in a dependency `lz4-c` that would be incompatible. 

Needed for : https://github.com/rapidsai/cudf/pull/7495/