### PR TITLE
Readd cuCIM

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - cudf ={{ minor_version }}.*
     - cugraph ={{ minor_version }}.*
     - cuml ={{ minor_version }}.*
-    # - cucim ={{ minor_version }}.*
+    - cucim ={{ minor_version }}.*
     - cusignal ={{ minor_version }}.*
     - cuspatial ={{ minor_version }}.*
     - custreamz ={{ minor_version }}.*


### PR DESCRIPTION
cuCIM was originally added in PR ( https://github.com/rapidsai/integration/pull/267 ), but needed to be temporarily disabled after due to conflicts ( https://github.com/rapidsai/integration/pull/275 ). As these should now be fixed, this readds cuCIM.