### PR TITLE
Fix `assert_eq` related import

### DIFF
--- a/test/dask-cudf/test_daskcudf.py
+++ b/test/dask-cudf/test_daskcudf.py
@@ -1,7 +1,7 @@
 import pytest
 import subprocess
 
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 __numGPUSkipReason = ""
 


### PR DESCRIPTION
Recently there has been a change of location of where the testing utils of cudf reside. This PR is adapting to those changes.

reference: https://github.com/rapidsai/cudf/pull/7495/