### PR TITLE
Remove `ubuntu16.04` from axis files [skip ci]

### DIFF
--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -13,7 +13,6 @@ CUDA_VER:
   - 11.0
 
 LINUX_VER:
-  - ubuntu16.04
   - ubuntu18.04
   - ubuntu20.04
   - centos7


### PR DESCRIPTION
This PR removes `ubuntu16.04` from the axes files since we no longer support it.