### PR TITLE
[gpuCI] Forward-merge branch-21.08 to branch-21.10 [skip ci]

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -81,7 +81,7 @@ gtest_version:
 ipython_version:
   - '=7.15'
 isort_version:
-  - '=5.0'
+  - '=5.6.4'
 jupyterlab_version:
   - '>=3.0.0,<4.0a0'
 jupyter_packaging_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -73,7 +73,7 @@ geopandas_version:
 gcsfs_version:
   - '>=0.8.0'
 google_cloud_cpp_version:
-  - '=1.25.0'
+  - '>=1.25.0'
 gmock_version:
   - '=1.10.0'
 gtest_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.08` that creates a PR to keep `branch-21.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.