### PR TITLE
Upgrade to Treelite 2.0.0

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -153,4 +153,4 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=1.3.0'
+  - '=2.0.0'


### PR DESCRIPTION
Required by rapidsai/cuml#4072. See the CI result in rapidsai/cuml#4072 which is testing cuML with Treelite 2.0.0.