### PR TITLE
[REVIEW] ENH Add 21.10 meta packages to nightly builds

### DIFF
--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -7,6 +7,7 @@ CONDA_CONFIG_FILE:
 # Use M.X.Ya (major.minor.patch) with 'a' version to match nightly tag
 RAPIDS_VER:
   - 21.08.00a
+  - 21.10.00a
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -7,6 +7,7 @@ DOCKER_REPO:
 # Use M.X (major.minor) version
 RAPIDS_VER:
   - "21.08"
+  - "21.10"
 
 CUDA_VER:
   - 11.2


### PR DESCRIPTION
Adds 21.10 to the axis to get the next version of meta packages published. This is required for 21.10 images to be released, which is blocking newly created PRs to the latest dev branch.