### PR TITLE
Pinning spdlog version to 1.8.5

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -149,7 +149,7 @@ scipy_version:
 setuptools_version:
   - '>=49,<50'
 spdlog_version:
-  - '>=1.8.5,<2.0.0a0'
+  - '=1.8.5'
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -149,7 +149,7 @@ scipy_version:
 setuptools_version:
   - '>=49,<50'
 spdlog_version:
-  - '=1.8.5'
+  - '>=1.8.5,<1.9'
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:


### PR DESCRIPTION
A new conda package for spdlog was released last night and it's causing a build issue in cuml. We've decided to pin the version to 1.8.5 in the meantime to unblock CI (and potentially for release 21.08). 

https://github.com/rapidsai/cuml/issues/4078