### PR TITLE
Temporarily remove `pyppeteer`

### DIFF
--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -6,7 +6,7 @@ CONDA_CONFIG_FILE:
 
 # Use M.X.Y (major.minor.patch) version to match tag
 RAPIDS_VER:
-  - "21.06.00"
+  - "21.06.01"
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -117,7 +117,7 @@ requirements:
     - pydocstyle {{ pydocstyle_version }}
     - pynvml
     - pyorc
-    - pyppeteer {{ pyppeteer_version }}
+    # - pyppeteer {{ pyppeteer_version }}
     - pyproj {{ pyproj_version }}
     - pytest
     - pytest-asyncio {{ pytest_asyncio_version }}


### PR DESCRIPTION
This PR temporarily removes `pyppeteer` from `rapids-build-env` until [this CVE issue](https://github.com/pyppeteer/pyppeteer/issues/275#issuecomment-882838194) is resolved.