### PR TITLE
[gpuCI] Forward-merge branch-21.08 to branch-21.10 [skip ci]

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -153,4 +153,4 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=1.3.0'
+  - '=2.0.0'

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -149,7 +149,7 @@ scipy_version:
 setuptools_version:
   - '>=49,<50'
 spdlog_version:
-  - '>=1.8.5,<2.0.0a0'
+  - '>=1.8.5,<1.9'
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -73,7 +73,7 @@ geopandas_version:
 gcsfs_version:
   - '>=0.8.0'
 google_cloud_cpp_version:
-  - '=1.25.0'
+  - '>=1.25.0'
 gmock_version:
   - '=1.10.0'
 gtest_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.08` that creates a PR to keep `branch-21.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.