### PR TITLE
Update `conda` version

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -13,7 +13,7 @@ xgboost_version:
 
 # Versions for conda
 conda_version:
-  - '=4.8.3'
+  - '=4.10.3'
 conda_build_version:
   - '=3.20.3'
 conda_verify_version:


### PR DESCRIPTION
This PR updates the `conda` version to match https://github.com/rapidsai/gpuci-build-environment/pull/198.