### PR TITLE
Upgrade arrow to `5.0.0`

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -25,7 +25,7 @@ build_stack_version:
 
 # Shared versions across meta-pkgs
 arrow_version:
-  - '=4.0.1'
+  - '=5.0.0'
 benchmark_version:
   - '=1.5.1'
 black_version:


### PR DESCRIPTION
Required for: https://github.com/rapidsai/cudf/pull/8908/

This PR upgrades arrow version to `5.0.0`