### PR TITLE
[REVIEW] FIX Temporarily ignore blazing failures

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -111,7 +111,7 @@ if [[ "$BUILD_PKGS" == "meta" || -z "$BUILD_PKGS" ]] ; then
   # Run builds for meta-pkgs
   run_builds $CONDA_XGBOOST_RECIPE
   run_builds $CONDA_RAPIDS_RECIPE
-  run_builds $CONDA_RAPIDS_BLAZING_RECIPE
+  run_builds $CONDA_RAPIDS_BLAZING_RECIPE || true
 fi
 
 if [[ "$BUILD_PKGS" == "env" || -z "$BUILD_PKGS" ]] ; then


### PR DESCRIPTION
This PR is a temporary patch to ignore any rapids-blazing failures during release since blazing will not be available.