### PR TITLE
[gpuCI] Forward-merge branch-21.08 to branch-21.10 [skip gpuci]

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -111,7 +111,7 @@ if [[ "$BUILD_PKGS" == "meta" || -z "$BUILD_PKGS" ]] ; then
   # Run builds for meta-pkgs
   run_builds $CONDA_XGBOOST_RECIPE
   run_builds $CONDA_RAPIDS_RECIPE
-  run_builds $CONDA_RAPIDS_BLAZING_RECIPE
+  run_builds $CONDA_RAPIDS_BLAZING_RECIPE || true
 fi
 
 if [[ "$BUILD_PKGS" == "env" || -z "$BUILD_PKGS" ]] ; then

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -13,7 +13,7 @@ xgboost_version:
 
 # Versions for conda
 conda_version:
-  - '=4.8.3'
+  - '=4.10.3'
 conda_build_version:
   - '=3.20.3'
 conda_verify_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.08` that creates a PR to keep `branch-21.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.