### PR TITLE
Set minimum `pydata-sphinx-theme` version

### DIFF
--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - nbsphinx {{ nbsphinx_version }}
     - numpydoc
     - pandoc {{ pandoc_version }}
-    - pydata-sphinx-theme
+    - pydata-sphinx-theme {{ pydata_sphinx_theme_version }}
     - recommonmark
     - sphinx
     - sphinx_rtd_theme

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -130,6 +130,8 @@ pytorch_version:
   - '>=1.6'
 protobuf_version:
   - '>=3.4.1,<4.0.0'
+pydata_sphinx_theme_version:
+  - '>=0.6.3'
 pyproj_version:
   - '>=2.4,<=3.1'
 pyppeteer_version:


### PR DESCRIPTION
This PR pins the version of `pydata-sphinx-theme` to at least `0.6.3.` This is necessary because `conda` was solving for version `0.6.1` which has issues with some versions of `jinja` and therefore was causing errors during docs builds.