### PR TITLE
#1625: Use cugraph's test.sh script in integration tests

### DIFF
--- a/ci/test/cugraph.sh
+++ b/ci/test/cugraph.sh
@@ -1,47 +1,12 @@
 #!/bin/bash
 set +e
 set -x
+
 export HOME="${WORKSPACE}"
 export LIBCUDF_KERNEL_CACHE_PATH="${WORKSPACE}/.jitcache"
 export PATH="/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/local/gcc7/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-# FIXME: "source activate" line should not be needed
 source /opt/conda/bin/activate rapids
 
-# Get datasets
-cd /rapids/cugraph/datasets
-bash ./get_test_data.sh
-export RAPIDS_DATASET_ROOT_DIR=/rapids/cugraph/datasets
-
-# Show environment
-env
-nvidia-smi
-conda list
-
-# Install pytest plugin for cugraph
-conda install rapids-pytest-benchmark
-
-TESTRESULTS_DIR="${WORKSPACE}/testresults"
-mkdir -p ${TESTRESULTS_DIR}
-SUITEERROR=0
-
-# gtests
-for gt in /rapids/cugraph/cpp/build/tests/*_TEST; do
-   # FIXME: remove this ASAP
-   ${gt} --gtest_output=xml:${TESTRESULTS_DIR}/
-   exitcode=$?
-   if (( ${exitcode} != 0 )); then
-      SUITEERROR=${exitcode}
-      echo "FAILED: ${gt}"
-   fi
-done
-
-# Python tests
-pytest --ignore=/rapids/cugraph/python/cugraph/raft --junitxml=${TESTRESULTS_DIR}/pytest.xml -v /rapids/cugraph/python
-exitcode=$?
-if (( ${exitcode} != 0 )); then
-   SUITEERROR=${exitcode}
-   echo "FAILED: 1 or more tests in /rapids/cugraph/python"
-fi
-
-exit ${SUITEERROR}
+cd /rapids/cugraph
+bash /rapids/cugraph/ci/test.sh


### PR DESCRIPTION
# Summary
This PR uses cugraph's `test.sh` script instead

# Testing Evidence
https://gpuci.gpuopenanalytics.com/job/rapidsai/job/nightly-tests/job/docker-test-cugraph/961/console