### PR TITLE
Add jupyterlab-favorites to notebook env

### DIFF
--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -51,6 +51,7 @@ requirements:
     - ipywidgets
     - jupyter-server-proxy
     - jupyterlab {{ jupyterlab_version }}
+    - jupyterlab-favorites
     - jupyterlab-nvdashboard
     - jupyter-packaging {{ jupyter_packaging_version }}
     - jupyterlab_widgets


### PR DESCRIPTION
When starting Jupyter Lab you need to decide which directory the file explorer starts in. In some RAPIDS deployment environments it is not always obvious which directory you should choose. Should it be `/rapids`, or `$HOME`? There may also be datasets or workspaces mounted in HPC/cloud environments which may be the actual desired workspace.

Today I came across this nice small Jupyter Lab extension from NERSC. It adds a favourite directories section at the top of the file explorer in Jupyter Lab and allows users to add and remove directories. 

<img width="410" alt="image" src="https://user-images.githubusercontent.com/1610850/132666010-eda793ae-a219-4af7-8bb5-2190e096f023.png">

It seems particularly useful because an admin can drop in a config ahead of time with some useful directories. I intend to raise a follow-up PR to rapidsai/docker to add `/rapids` and `$HOME` to this default list.