### PR TITLE
Update scikit-learn to 0.24

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -145,7 +145,7 @@ s3fs_version:
 scikit_image_version:
   - '>=0.18.0,<0.19.0'
 scikit_learn_version:
-  - '=0.23.1'
+  - '=0.24'
 scipy_version:
   - '=1.6.0'
 setuptools_version:


### PR DESCRIPTION
Depends on https://github.com/rapidsai/cuml/pull/4205 so cuML is not blocked, updates Scikit-learn to the latest official release. 