### PR TITLE
Update notebook test script path

### DIFF
--- a/ci/test/notebooks.sh
+++ b/ci/test/notebooks.sh
@@ -26,6 +26,6 @@ conda list
 
 /test.sh 2>&1 | tee nbtest.log
 EXITCODE=$?
-python /rapids/utils/nbtestlog2junitxml.py nbtest.log
+python /rapids/notebooks/test/nbtestlog2junitxml.py nbtest.log
 
 exit ${EXITCODE}


### PR DESCRIPTION
**Depends on https://github.com/rapidsai/docker/pull/362**

This PR updates the path to `nbtestlog2junitxml.py` since it was changed in https://github.com/rapidsai/notebooks/pull/345 and https://github.com/rapidsai/docker/pull/362.