### PR TITLE
add pyppeteer version >=0.2.6

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -116,7 +116,7 @@ requirements:
     - pydocstyle {{ pydocstyle_version }}
     - pynvml
     - pyorc
-    # - pyppeteer {{ pyppeteer_version }}
+    - pyppeteer {{ pyppeteer_version }}
     - pyproj {{ pyproj_version }}
     - pytest
     - pytest-asyncio {{ pytest_asyncio_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -135,7 +135,7 @@ pydata_sphinx_theme_version:
 pyproj_version:
   - '>=2.4,<=3.1'
 pyppeteer_version:
-  - '<=0.2.2'
+  - '>=0.2.6'
 pytest_asyncio_version:
   - '<0.14.0'
 rapidjson_version:


### PR DESCRIPTION
Adds pyppeteer version >=0.2.6 removed in a previous PR due to CI issues. 

Also fixes failing CI in [this cuxfilter PR](https://github.com/rapidsai/cuxfilter/pull/322).

cc @ajschmidt8 