### PR TITLE
[gpuCI] Forward-merge branch-21.10 to branch-21.12 [skip gpuci]

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -139,7 +139,7 @@ requirements:
     - spdlog {{ spdlog_version }}
     - statsmodels
     - streamz
-    - transformers
+    - transformers {{ transformers_version }}
     - treelite {{ treelite_version }}
     - twine
     - typing_extensions

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -116,7 +116,7 @@ requirements:
     - pydocstyle {{ pydocstyle_version }}
     - pynvml
     - pyorc
-    # - pyppeteer {{ pyppeteer_version }}
+    - pyppeteer {{ pyppeteer_version }}
     - pyproj {{ pyproj_version }}
     - pytest
     - pytest-asyncio {{ pytest_asyncio_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -135,7 +135,7 @@ pydata_sphinx_theme_version:
 pyproj_version:
   - '>=2.4,<=3.1'
 pyppeteer_version:
-  - '<=0.2.2'
+  - '>=0.2.6'
 pytest_asyncio_version:
   - '<0.14.0'
 rapidjson_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -156,3 +156,5 @@ sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
   - '=2.1.0'
+transformers_version:
+  - '<=4.10.3'

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -47,11 +47,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '>=2021.9.1,<2021.10.0'
+  - '=2021.9.1'
 datashader_version:
   - '>=0.11.1,<0.12'
 distributed_version:
-  - '>=2021.9.1,<2021.10.0'
+  - '=2021.9.1'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.10` that creates a PR to keep `branch-21.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.