### PR TITLE
Skip imports tests on arm64

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -57,13 +57,13 @@ requirements:
     - rapids-xgboost ={{ minor_version }}.*
     - rmm ={{ minor_version }}.*
 
-test:
-  imports:
-    - cudf
-    - dask_cudf
-    - cuml
-    - cugraph
-    - cuspatial
+test:            # [linux64]
+  imports:       # [linux64]
+    - cudf       # [linux64]
+    - dask_cudf  # [linux64]
+    - cuml       # [lunux64]
+    - cugraph    # [linux64]
+    - cuspatial  # [linux64]
 
 about:
   home: http://rapids.ai/


### PR DESCRIPTION
Due to a driver bug, we cannot run imports tests on CPU nodes on arm64