### PR TITLE
Remove `PYTHONPATH` variable from `cudf` tests

### DIFF
--- a/ci/test/cudf.sh
+++ b/ci/test/cudf.sh
@@ -26,14 +26,6 @@ for gt in /rapids/cudf/cpp/build/gtests/*; do
    fi
 done
 
-# Python tests
-export PYTHONPATH=\
-/rapids/cudf/python/cudf:\
-/rapids/cudf/python/dask_cudf:\
-/rapids/cudf/python/custreamz:\
-/rapids/cudf/python/nvstrings:\
-${PYTHONPATH}
-
 cd /rapids/cudf/python/cudf
 py.test -n 6 --junitxml=${TESTRESULTS_DIR}/pytest-cudf.xml -v
 exitcode=$?


### PR DESCRIPTION
This PR removes the `PYTHONPATH` variable from the `cudf` test script that runs in our `devel` containers.

The current value of this environment variable implies that `cudf` (and associated libraries) are installed in-place (i.e. in the source repo itself). However, our current `cudf` installation steps _do not_ perform an in-place installation (as is evident by the missing [`-n` flag ](https://github.com/rapidsai/cudf/blob/fc341af414a64d6a82a2c2fbb23cf12ff2417200/build.sh#L34)in our [install steps here](https://github.com/rapidsai/docker/blob/38593c86ce2bfdb742c22c49b5da4753a8e0b12f/generated-dockerfiles/rapidsai-core_ubuntu18.04-devel.Dockerfile#L157-L159)). Instead, `cudf` is installed into the `conda` environment which causes most of our tests to fail.

In the future, we should update all of the libraries in our `devel` containers to perform an in-place install and add any necessary `PYTHONPATH` values to the Docker container itself.