### PR TITLE
Change `cudf` test directory

### DIFF
--- a/ci/test/cudf.sh
+++ b/ci/test/cudf.sh
@@ -26,8 +26,8 @@ for gt in /rapids/cudf/cpp/build/gtests/*; do
    fi
 done
 
-cd /rapids/cudf/python/cudf
-py.test -n 6 --junitxml=${TESTRESULTS_DIR}/pytest-cudf.xml -v
+cd /rapids/cudf/python/cudf/cudf/tests
+pytest -n 6 --junitxml=${TESTRESULTS_DIR}/pytest-cudf.xml -v
 exitcode=$?
 if (( ${exitcode} != 0 )); then
    SUITEERROR=${exitcode}
@@ -35,7 +35,7 @@ if (( ${exitcode} != 0 )); then
 fi
 
 cd /rapids/cudf/python/dask_cudf
-py.test -n 6 --junitxml=${TESTRESULTS_DIR}/pytest-dask-cudf.xml -v
+pytest -n 6 --junitxml=${TESTRESULTS_DIR}/pytest-dask-cudf.xml -v
 exitcode=$?
 if (( ${exitcode} != 0 )); then
    SUITEERROR=${exitcode}
@@ -43,7 +43,7 @@ if (( ${exitcode} != 0 )); then
 fi
 
 cd /rapids/cudf/python/custreamz
-py.test -n 6 --junitxml=${TESTRESULTS_DIR}/pytest-custreamz.xml -v
+pytest -n 6 --junitxml=${TESTRESULTS_DIR}/pytest-custreamz.xml -v
 exitcode=$?
 if (( ${exitcode} != 0 )); then
    SUITEERROR=${exitcode}


### PR DESCRIPTION
This PR updates the `cudf` test directory to `/rapids/cudf/python/cudf/cudf/tests` to ensure that it excludes the `/rapids/cudf/python/cudf/cudf/benchmarks` directory, which is not currently working and does not need to be tested in CI.

Additionally, it changes the `py.test` command to `pytest` since `py.test` is considered deprecated ([src](https://stackoverflow.com/a/41893170)).