### PR TITLE
Update `google_cloud_cpp_version` Pin

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -73,7 +73,7 @@ geopandas_version:
 gcsfs_version:
   - '>=0.8.0'
 google_cloud_cpp_version:
-  - '>=1.25.0'
+  - '>=1.25.0,<1.30'
 gmock_version:
   - '=1.10.0'
 gtest_version:


### PR DESCRIPTION
This PR updates the version pin for the `google-cloud-cpp` package since our libraries are incompatible with anything higher than `1.3.0`.