### PR TITLE
[gpuCI] Forward-merge branch-21.10 to branch-21.12 [skip gpuci]

### DIFF
--- a/ci/axis/release-arm64.yaml
+++ b/ci/axis/release-arm64.yaml
@@ -1,0 +1,20 @@
+CONDA_USERNAME:
+  - rapidsai
+
+CONDA_CONFIG_FILE:
+  - conda/recipes/versions.yaml
+
+# Use M.X.Y (major.minor.patch) version to match tag
+RAPIDS_VER:
+  - "21.10.00"
+
+# Use CUDA_VER to not clobber `CUDA_VERSION` in the container
+CUDA_VER:
+  - 11.4
+  - 11.2
+
+PYTHON_VER:
+  - 3.7
+  - 3.8
+
+exclude:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -73,7 +73,7 @@ geopandas_version:
 gcsfs_version:
   - '>=0.8.0'
 google_cloud_cpp_version:
-  - '>=1.25.0'
+  - '>=1.25.0,<1.30'
 gmock_version:
   - '=1.10.0'
 gtest_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.10` that creates a PR to keep `branch-21.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.