### PR TITLE
Update Runtime Image for Nightly Tests

### DIFF
--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -1,5 +1,5 @@
 RUNTIME_DOCKER_REPO:
-  - rapidsai/rapidsai-nightly
+  - rapidsai/rapidsai-core-nightly
 
 DOCKER_REPO:
   - rapidsai/rapidsai-core-dev-nightly


### PR DESCRIPTION
This PR updates the image that's used for our nightly tests. There is currently no `rapidsai-nightly` images planned for `21.12` since BlazingSQL has been discontinued, so this PR switches the image to use `rapidsai-core-nightly`.