### PR TITLE
Add pre-commit to environment.

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -109,7 +109,7 @@ requirements:
     - panel {{ panel_version }}
     - pickle5  # [py<38]
     - pkg-config
-    - pre_commit
+    - pre-commit
     - protobuf {{ protobuf_version }}
     - psutil
     - pyarrow {{ arrow_version }}

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -109,6 +109,7 @@ requirements:
     - panel {{ panel_version }}
     - pickle5  # [py<38]
     - pkg-config
+    - pre_commit
     - protobuf {{ protobuf_version }}
     - psutil
     - pyarrow {{ arrow_version }}


### PR DESCRIPTION
The cudf team is planning to replace manual invocation of linters in CI with pre-commit. We need pre-commit installed in the CI environment for this to work.