### PR TITLE
Unpin setuptools version

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -149,7 +149,7 @@ scikit_learn_version:
 scipy_version:
   - '=1.6.0'
 setuptools_version:
-  - '>=49,<50'
+  - '>50'
 spdlog_version:
   - '>=1.8.5,<1.9'
 sphinx_markdown_tables_version:


### PR DESCRIPTION
Unpin `setuptools`. Require `setuptool>50` as version `50` is broken