### PR TITLE
change minimum s3fs version

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -141,7 +141,7 @@ pytest_asyncio_version:
 rapidjson_version:
   - '=1.1.0'
 s3fs_version:
-  - '>=0.5.2'
+  - '>=2021.08.0'
 scikit_image_version:
   - '>=0.18.0,<0.19.0'
 scikit_learn_version:


### PR DESCRIPTION
There are new issues that have come up because of a recent release of `aiobotocore` which is a dependency in `s3fs`. `s3fs>=2021.08.0` has fixed this issue hence, upgrading the minimum pin.


error log:
https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cudf/job/prb/job/cudf-gpu-test/CUDA=11.0,GPU_LABEL=gpu-a100,LINUX_VER=centos7,PYTHON=3.7/4699/testReport/junit/cudf.tests/test_s3/test_read_csv_32_/