### PR TITLE
[gpuCI] Forward-merge branch-21.12 to branch-22.02 [skip gpuci]

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -9,7 +9,7 @@ dask_xgboost_version:
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
   # Minor version is appended in meta.yaml
-  - '=1.4.2dev.rapidsai'
+  - '=1.5.0dev.rapidsai'
 
 # Versions for conda
 conda_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -35,7 +35,7 @@ bokeh_version:
 boost_cpp_version:
   - '=1.72.0'
 clang_version:
-  - '=11.0.0'
+  - '=11.1.0'
 cmake_version:
   - '>=3.20.1,<3.21'
 cmake_format_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.12` that creates a PR to keep `branch-22.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.