### PR TITLE
[gpuCI] Forward-merge branch-21.12 to branch-22.02 [skip gpuci]

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -56,6 +56,7 @@ requirements:
     - dask-cuda ={{ minor_version }}.*
     - rapids-xgboost ={{ minor_version }}.*
     - rmm ={{ minor_version }}.*
+    - ptxcompiler  # [linux64]  # CUDA enhanced compat. See https://github.com/rapidsai/ptxcompiler
 
 test:            # [linux64]
   imports:       # [linux64]

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -35,7 +35,7 @@ bokeh_version:
 boost_cpp_version:
   - '=1.72.0'
 clang_version:
-  - '=11.0.0'
+  - '=11.1.0'
 cmake_version:
   - '>=3.20.1,<3.21'
 cmake_format_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -43,7 +43,7 @@ cmake_format_version:
 cmake_setuptools_version:
   - '>=0.1.3'
 cupy_version:
-  - '>=8.5.0,<10.0.0a0'
+  - '>=9.5.0,<10.0.0a0'
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.12` that creates a PR to keep `branch-22.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.