### PR TITLE
Add `mock` package to `rapids-build-env`

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -94,6 +94,7 @@ requirements:
     - lightgbm
     - make
     - mimesis {{ mimesis_version }}
+    - mock
     - moto {{ moto_version }}
     - mypy {{ mypy_version }}
     - nccl {{ nccl_version }}


### PR DESCRIPTION
This PR adds the `mock` package to `rapids-build-env`. `mock` used to be included by the `moto` package, but the `moto` package was recently upgraded and removed its dependency on `mock` which caused some issues for `cuxfilter`. So we need to include `mock` explicitly.