### PR TITLE
updated yaml files to remove 3.7 and include 3.9

### DIFF
--- a/ci/axis/nightly-arm64.yaml
+++ b/ci/axis/nightly-arm64.yaml
@@ -15,7 +15,7 @@ CUDA_VER:
   - 11.2
 
 PYTHON_VER:
-  - 3.7
+  - 3.9
   - 3.8
 
 exclude:

--- a/ci/axis/nightly.yaml
+++ b/ci/axis/nightly.yaml
@@ -16,7 +16,7 @@ CUDA_VER:
   - 11.0
 
 PYTHON_VER:
-  - 3.7
+  - 3.9
   - 3.8
 
 exclude:

--- a/ci/axis/release-arm64.yaml
+++ b/ci/axis/release-arm64.yaml
@@ -15,7 +15,7 @@ CUDA_VER:
   - 11.2
 
 PYTHON_VER:
-  - 3.7
+  - 3.9
   - 3.8
 
 exclude:

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -16,7 +16,7 @@ CUDA_VER:
   - 11.0
 
 PYTHON_VER:
-  - 3.7
+  - 3.9
   - 3.8
 
 exclude:

--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -21,6 +21,6 @@ LINUX_VER:
   - centos8
 
 PYTHON_VER:
-  - 3.7
+  - 3.9
 
 exclude:


### PR DESCRIPTION
Update python versions to only use 3.8 and 3.9 and remove 3.7.