### PR TITLE
Add `ptxcompiler` to `rapids-build-env`

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -114,6 +114,7 @@ requirements:
     - pre-commit
     - protobuf {{ protobuf_version }}
     - psutil
+    - ptxcompiler  # [linux64]  # CUDA enhanced compat. See https://github.com/rapidsai/ptxcompiler
     - pyarrow {{ arrow_version }}
     - pydeck {{ pydeck_version }}
     - pydocstyle {{ pydocstyle_version }}


### PR DESCRIPTION
Similarly to #389, this PR adds `ptxcompiler` to our `conda` recipes. Specifically, it adds it to `rapids-build-env` to ensure that it's included in `devel` images.