### PR TITLE
Fix cuda-python version spec

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - conda {{ conda_version }}
     - conda-build {{ conda_build_version }}
     - conda-verify {{ conda_verify_version }}
-    - cuda-python {{ cuda_python_version }}.*
+    - cuda-python {{ cuda_python_version }}
     - cudatoolkit ={{ cuda_version }}.*
     - cupy {{ cupy_version }}
     - cython {{ cython_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -43,7 +43,7 @@ cmake_format_version:
 cmake_setuptools_version:
   - '>=0.1.3'
 cuda_python_version:
-  - '>=11.5,<12.*'
+  - '>=11.5,<12'
 cupy_version:
   - '>=9.5.0,<10.0.0a0'
 cython_version:


### PR DESCRIPTION
`mamba` was choking on the version spec `>=11.5.0,<12.*.*`. This PR fixes the version spec to be just `>=11.5.0,<12` which works for both `conda` and `mamba`.