### PR TITLE
remove-jupyterlab-nvdashboard

### DIFF
--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -52,7 +52,6 @@ requirements:
     - jupyter-server-proxy
     - jupyterlab {{ jupyterlab_version }}
     - jupyterlab-favorites
-    - jupyterlab-nvdashboard
     - jupyter-packaging {{ jupyter_packaging_version }}
     - jupyterlab_widgets
     - matplotlib-base


### PR DESCRIPTION
Correct circular install loop with integration repo when creating rapids-noteb-env