### PR TITLE
Add CUDA 11.1 & 11.3 support to integration

### DIFF
--- a/ci/axis/nightly-env-arm64.yaml
+++ b/ci/axis/nightly-env-arm64.yaml
@@ -11,8 +11,6 @@ RAPIDS_VER:
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
   - 11.5
-  - 11.4
-  - 11.2
 
 PYTHON_VER:
   - 3.7

--- a/ci/axis/nightly-env.yaml
+++ b/ci/axis/nightly-env.yaml
@@ -11,9 +11,6 @@ RAPIDS_VER:
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
   - 11.5
-  - 11.4
-  - 11.2
-  - 11.0
 
 PYTHON_VER:
   - 3.7

--- a/ci/axis/nightly-meta-arm64.yaml
+++ b/ci/axis/nightly-meta-arm64.yaml
@@ -11,8 +11,6 @@ RAPIDS_VER:
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
   - 11.5
-  - 11.4
-  - 11.2
 
 PYTHON_VER:
   - 3.7

--- a/ci/axis/nightly-meta.yaml
+++ b/ci/axis/nightly-meta.yaml
@@ -11,9 +11,6 @@ RAPIDS_VER:
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
   - 11.5
-  - 11.4
-  - 11.2
-  - 11.0
 
 PYTHON_VER:
   - 3.7

--- a/ci/axis/release-arm64.yaml
+++ b/ci/axis/release-arm64.yaml
@@ -11,8 +11,6 @@ RAPIDS_VER:
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
   - 11.5
-  - 11.4
-  - 11.2
 
 PYTHON_VER:
   - 3.7

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -11,9 +11,6 @@ RAPIDS_VER:
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
   - 11.5
-  - 11.4
-  - 11.2
-  - 11.0
 
 PYTHON_VER:
   - 3.7

--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -10,9 +10,6 @@ RAPIDS_VER:
 
 CUDA_VER:
   - 11.5
-  - 11.4
-  - 11.2
-  - 11.0
 
 LINUX_VER:
   - ubuntu18.04

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -4,6 +4,7 @@
 {% set minor_version = rapids_version.split('.')[0] + '.' + rapids_version.split('.')[1] %}
 {% set cuda_version = '.'.join(environ.get('CUDA_VER', '10.0').split('.')[:2]) %}
 {% set py_version = environ.get('CONDA_PY', 36) %}
+{% set cuda_major=cuda_version.split('.')[0] %}
 
 ###
 # Versions referenced below are set in `conda/recipe/*versions.yaml` except for
@@ -25,7 +26,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda{{ cuda_version }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: cuda{{ cuda_major }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - CUDA_VERSION
     - RAPIDS_VER
@@ -56,7 +57,7 @@ requirements:
     - conda-build {{ conda_build_version }}
     - conda-verify {{ conda_verify_version }}
     - cuda-python {{ cuda_python_version }}
-    - cudatoolkit ={{ cuda_version }}.*
+    - cudatoolkit ={{ cuda_major }}.*
     - cupy {{ cupy_version }}
     - cython {{ cython_version }}
     - dask {{ dask_version }}

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -4,6 +4,7 @@
 {% set minor_version = rapids_version.split('.')[0] + '.' + rapids_version.split('.')[1] %}
 {% set cuda_version = '.'.join(environ.get('CUDA_VER', '10.0').split('.')[:2]) %}
 {% set py_version = environ.get('CONDA_PY', 36) %}
+{% set cuda_major=cuda_version.split('.')[0] %}
 
 ###
 # Versions referenced below are set in `conda/recipe/*versions.yaml` except for
@@ -25,7 +26,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda{{ cuda_version }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: cuda{{ cuda_major }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - CUDA_VERSION
     - RAPIDS_VER
@@ -38,7 +39,7 @@ requirements:
     - bokeh {{ bokeh_version }}
     - colorcet
     - conda-forge::blas
-    - cudatoolkit ={{ cuda_version }}.*
+    - cudatoolkit ={{ cuda_major }}.*
     - cupy {{ cupy_version }}
     - cython {{ cython_version }}
     - dask-labextension

--- a/conda/recipes/rapids-xgboost/meta.yaml
+++ b/conda/recipes/rapids-xgboost/meta.yaml
@@ -4,6 +4,7 @@
 {% set minor_version = rapids_version.split('.')[0] + '.' + rapids_version.split('.')[1] %}
 {% set cuda_version = '.'.join(environ.get('CUDA_VER', '10.0').split('.')[:2]) %}
 {% set py_version = environ.get('CONDA_PY', 36) %}
+{% set cuda_major=cuda_version.split('.')[0] %}
 
 ###
 # Versions referenced below are set in `conda/recipe/*versions.yaml` except for
@@ -25,7 +26,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda{{ cuda_version }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: cuda{{ cuda_major }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - CUDA_VERSION
     - RAPIDS_VER
@@ -35,7 +36,7 @@ requirements:
   host:
     - python
   run:
-    - cudatoolkit ={{ cuda_version }}.*
+    - cudatoolkit ={{ cuda_major }}.*
     - nccl {{ nccl_version }}
     - python
     - xgboost {{ xgboost_version }}{{ minor_version }}

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -4,6 +4,7 @@
 {% set minor_version = rapids_version.split('.')[0] + '.' + rapids_version.split('.')[1] %}
 {% set cuda_version = '.'.join(environ.get('CUDA_VER', '10.0').split('.')[:2]) %}
 {% set py_version = environ.get('CONDA_PY', 36) %}
+{% set cuda_major=cuda_version.split('.')[0] %}
 
 ###
 # Versions referenced below are set in `conda/recipe/*versions.yaml` except for
@@ -25,7 +26,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda{{ cuda_version }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: cuda{{ cuda_major }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - CUDA_VERSION
     - RAPIDS_VER
@@ -36,7 +37,7 @@ requirements:
     - python
   run:
     - cuda-python {{ cuda_python_version }}
-    - cudatoolkit ={{ cuda_version }}.*
+    - cudatoolkit ={{ cuda_major }}.*
     - cupy {{ cupy_version }}
     - nccl {{ nccl_version }}
     - networkx {{ networkx_version }}


### PR DESCRIPTION
This PR updates the recipes [here](https://github.com/rapidsai/integration/tree/branch-22.02/conda/recipes) to ensure that the `cudatoolkit` version specifications are equivalent to `11.*`. 

It also updates the [axis](https://github.com/rapidsai/integration/tree/branch-22.02/ci/axis) files so that our integration packages are aligned with our library packages for CUDA Enhanced Compatibility where we build on the latest CUDA version (i.e. `11.5`), but can run on any earlier `11.x` version.