### PR TITLE
Upgrade to Treelite 2.2.1

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -159,6 +159,6 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=2.1.0'
+  - '=2.2.0'
 transformers_version:
   - '<=4.10.3'

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -159,6 +159,6 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=2.2.0'
+  - '=2.2.1'
 transformers_version:
   - '<=4.10.3'


### PR DESCRIPTION
Required by rapidsai/cuml#4484. See the CI result in rapidsai/cuml#4484 which is testing cuML with Treelite 2.2.0.

EDIT. Using 2.2.1 patch release, to incorporate a hotfix (dmlc/treelite#340).