### PR TITLE
Allow CuPy 10

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -45,7 +45,7 @@ cmake_setuptools_version:
 cuda_python_version:
   - '>=11.5,<12'
 cupy_version:
-  - '>=9.5.0,<10.0.0a0'
+  - '>=9.5.0,<11.0.0a0'
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:


### PR DESCRIPTION
Relaxes version constraints to allow CuPy 10.

xref: https://github.com/rapidsai/cudf/pull/10048
xref: https://github.com/rapidsai/cuml/pull/4487
xref: https://github.com/rapidsai/cucim/pull/195
xref: https://github.com/rapidsai/cusignal/pull/448