### PR TITLE
allow scikit-image 0.19 in the conda environment

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -147,7 +147,7 @@ rapidjson_version:
 s3fs_version:
   - '>=2021.08.0'
 scikit_image_version:
-  - '>=0.18.0,<0.19.0'
+  - '>=0.18.0,<0.20.0'
 scikit_learn_version:
   - '=0.24'
 scipy_version:


### PR DESCRIPTION
This PR is to allow scikit-image 0.19 in the test environment as requested in https://github.com/rapidsai/cucim/pull/190#pullrequestreview-848290209. It is not strictly necessary to update to 0.19 in order for the tests in that PR to pass (the scikit-image package is mainly used to retrieve example data that is used in the tests for cuCIM and all the datasets we use are already present in 0.18)
