### PR TITLE
Bump Numpy version to 1.19 for Python 3.9

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -113,7 +113,7 @@ nodejs_version:
 numba_version:
   - '>=0.54'
 numpy_version:
-  - '>=1.17.3'
+  - '>=1.19'
 nvtx_version:
   - '>=0.2.1,<0.3'
 openjdk_version:


### PR DESCRIPTION
Python 3.9 requires `numpy>=1.18`