### PR TITLE
[gpuCI] Forward-merge branch-22.02 to branch-22.04 [skip gpuci]

### DIFF
--- a/ci/axis/nightly-env-arm64.yaml
+++ b/ci/axis/nightly-env-arm64.yaml
@@ -13,7 +13,6 @@ CUDA_VER:
   - 11.5
 
 PYTHON_VER:
-  - 3.7
   - 3.8
   - 3.9
 

--- a/ci/axis/nightly-env.yaml
+++ b/ci/axis/nightly-env.yaml
@@ -13,7 +13,6 @@ CUDA_VER:
   - 11.5
 
 PYTHON_VER:
-  - 3.7
   - 3.8
   - 3.9
 

--- a/ci/axis/nightly-meta-arm64.yaml
+++ b/ci/axis/nightly-meta-arm64.yaml
@@ -13,7 +13,7 @@ CUDA_VER:
   - 11.5
 
 PYTHON_VER:
-  - 3.7
   - 3.8
+  - 3.9
 
 exclude:

--- a/ci/axis/nightly-meta.yaml
+++ b/ci/axis/nightly-meta.yaml
@@ -13,7 +13,7 @@ CUDA_VER:
   - 11.5
 
 PYTHON_VER:
-  - 3.7
   - 3.8
+  - 3.9
 
 exclude:

--- a/ci/axis/release-arm64.yaml
+++ b/ci/axis/release-arm64.yaml
@@ -13,7 +13,7 @@ CUDA_VER:
   - 11.5
 
 PYTHON_VER:
-  - 3.7
   - 3.8
+  - 3.9
 
 exclude:

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -13,7 +13,7 @@ CUDA_VER:
   - 11.5
 
 PYTHON_VER:
-  - 3.7
   - 3.8
+  - 3.9
 
 exclude:

--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -18,7 +18,6 @@ LINUX_VER:
   - centos8
 
 PYTHON_VER:
-  - 3.7
   - 3.8
 
 exclude:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -113,7 +113,7 @@ nodejs_version:
 numba_version:
   - '>=0.54'
 numpy_version:
-  - '>=1.17.3'
+  - '>=1.19'
 nvtx_version:
   - '>=0.2.1,<0.3'
 openjdk_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.02` that creates a PR to keep `branch-22.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.