### PR TITLE
Update pillow package

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -112,6 +112,7 @@ requirements:
     - pandas {{ pandas_version }}
     - panel {{ panel_version }}
     - pickle5  # [py<38]
+    - pillow {{ pillow_version }}
     - pkg-config
     - pre-commit
     - protobuf {{ protobuf_version }}

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -59,6 +59,7 @@ requirements:
     - nodejs {{ nodejs_version }}
     - openslide
     - pytest
+    - pillow {{ pillow_version }}
     - s3fs {{ s3fs_version }}
     - scikit-image {{ scikit_image_version }}
     - scikit-learn {{ scikit_learn_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -83,7 +83,7 @@ gtest_version:
 holoviews_version:
   - '>1.14.1,<=1.14.6'
 ipython_version:
-  - '=7.31.0'
+  - '=7.31.1'
 isort_version:
   - '=5.6.4'
 jupyterlab_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -124,6 +124,8 @@ pandoc_version:
   - '<=2.0.0'
 panel_version:
   - '>=0.10.3'
+pillow_version:
+  - '>=9.0.0'
 pydeck_version:
   - '>=0.3, <=0.5.0'
 pydocstyle_version:


### PR DESCRIPTION
Pillow package older than 9.0.0 is causing the following critical CVEs during pulse security scans.  Updates pillow version in builds that use any of the following packages ['bokeh', 'imageio', 'datashader', 'scikit-image', 'matplotlib-base'].  

Affected CVEs:
https://github.com/advisories/GHSA-xrcv-f9gm-v42c
GHSA-xrcv-f9gm-v42c
https://github.com/advisories/GHSA-8vj2-vxx3-667w
GHSA-8vj2-vxx3-667w
https://github.com/advisories/GHSA-pw3c-h7wp-cvhx
GHSA-pw3c-h7wp-cvhx