### PR TITLE
add update jupyterlab version

### DIFF
--- a/ci/axis/nightly-env-arm64.yaml
+++ b/ci/axis/nightly-env-arm64.yaml
@@ -6,7 +6,7 @@ CONDA_CONFIG_FILE:
 
 # Use M.X.Ya (major.minor.patch) with 'a' version to match nightly tag
 RAPIDS_VER:
-  - 22.02.00a
+  - 22.04.00a
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/nightly-env.yaml
+++ b/ci/axis/nightly-env.yaml
@@ -6,7 +6,7 @@ CONDA_CONFIG_FILE:
 
 # Use M.X.Ya (major.minor.patch) with 'a' version to match nightly tag
 RAPIDS_VER:
-  - 22.02.00a
+  - 22.04.00a
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/nightly-meta-arm64.yaml
+++ b/ci/axis/nightly-meta-arm64.yaml
@@ -6,7 +6,7 @@ CONDA_CONFIG_FILE:
 
 # Use M.X.Ya (major.minor.patch) with 'a' version to match nightly tag
 RAPIDS_VER:
-  - 22.02.00a
+  - 22.04.00a
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/nightly-meta.yaml
+++ b/ci/axis/nightly-meta.yaml
@@ -6,7 +6,7 @@ CONDA_CONFIG_FILE:
 
 # Use M.X.Ya (major.minor.patch) with 'a' version to match nightly tag
 RAPIDS_VER:
-  - 22.02.00a
+  - 22.04.00a
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/release-arm64.yaml
+++ b/ci/axis/release-arm64.yaml
@@ -6,7 +6,7 @@ CONDA_CONFIG_FILE:
 
 # Use M.X.Y (major.minor.patch) version to match tag
 RAPIDS_VER:
-  - "22.02.00"
+  - "22.04.00"
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -6,7 +6,7 @@ CONDA_CONFIG_FILE:
 
 # Use M.X.Y (major.minor.patch) version to match tag
 RAPIDS_VER:
-  - "22.02.00"
+  - "22.04.00"
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -6,7 +6,7 @@ DOCKER_REPO:
 
 # Use M.X (major.minor) version
 RAPIDS_VER:
-  - "22.02"
+  - "22.04"
 
 CUDA_VER:
   - 11.5

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -87,7 +87,7 @@ ipython_version:
 isort_version:
   - '=5.6.4'
 jupyterlab_version:
-  - '>=3.0.0,<4.0a0'
+  - '>=3.1.4,<4.0a0'
 jupyter_packaging_version:
   - '>=0.7.0,<0.8'
 librdkafka_version:


### PR DESCRIPTION
Addressing remote code exploit found in pulse security scan.  Update to jupyter 3.1.4 correct error.

https://nvd.nist.gov/vuln/detail/CVE-2021-32797
https://github.com/jupyterlab/jupyterlab/security/advisories/GHSA-4952-p58q-6crx
