### PR TITLE
update jupyterlab version

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -87,7 +87,7 @@ ipython_version:
 isort_version:
   - '=5.6.4'
 jupyterlab_version:
-  - '>=3.0.0,<4.0a0'
+  - '>=3.1.4,<4.0a0'
 jupyter_packaging_version:
   - '>=0.7.0,<0.8'
 librdkafka_version:


### PR DESCRIPTION
CVE reported for remote code exploit for jupyterlab.  Update to 3.1.4 fixes problem.

https://github.com/jupyterlab/jupyterlab/commit/504825938c0abfa2fb8ff8d529308830a5ae42ed
https://github.com/jupyterlab/jupyterlab/security/advisories/GHSA-4952-p58q-6crx