### PR TITLE
Add scikit-build.

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -139,6 +139,7 @@ requirements:
     - ripgrep
     - s3fs {{ s3fs_version }}
     - setuptools
+    - scikit-build {{ scikit_build_version }}
     - scikit-image {{ scikit_image_version }}
     - scikit-learn {{ scikit_learn_version }}
     - scipy {{ scipy_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -148,6 +148,8 @@ rapidjson_version:
   - '=1.1.0'
 s3fs_version:
   - '>=2021.08.0'
+scikit_build_version:
+  - '=0.13.1'
 scikit_image_version:
   - '>=0.18.0,<0.20.0'
 scikit_learn_version:


### PR DESCRIPTION
scikit-build is a build tool to help glue together Python's setuptools and CMake. We are currently developing a POC of integrating it into RAPIDS in rapidsai/rmm#976.