### PR TITLE
Drop Python 3.7 requirements

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -111,7 +111,6 @@ requirements:
     - packaging
     - pandas {{ pandas_version }}
     - panel {{ panel_version }}
-    - pickle5  # [py<38]
     - pillow {{ pillow_version }}
     - pkg-config
     - pre-commit

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -44,7 +44,6 @@ requirements:
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}
     - nvtx {{ nvtx_version }}
-    - pickle5  # [py<38]
     - python
     - setuptools {{ setuptools_version }}
     - cudf ={{ minor_version }}.*


### PR DESCRIPTION
As we've dropped Python 3.7, we can also drop the requirements used with 3.7.