### PR TITLE
Upgrade to Treelite 2.3.0

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -163,6 +163,6 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=2.2.1'
+  - '=2.3.0'
 transformers_version:
   - '<=4.10.3'


### PR DESCRIPTION
Required by https://github.com/rapidsai/cuml/pull/4590. See the CI result in https://github.com/rapidsai/cuml/pull/4590 which is testing cuML with Treelite 2.3.0.