### PR TITLE
Remove libhwloc

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -88,7 +88,6 @@ requirements:
     - libcypher-parser
     - libgcc-ng {{ build_stack_version }}
     - libgfortran-ng {{ build_stack_version }}
-    - libhwloc
     - liblapack
     - librdkafka {{ librdkafka_version }}
     - libstdcxx-ng {{ build_stack_version }}


### PR DESCRIPTION
Since UCX < 1.11.1 support is being dropped by UCX-Py, it doesn't require libhwloc anymore so it may be removed.

UCX-Py PR removing libhwloc: https://github.com/rapidsai/ucx-py/pull/829