### PR TITLE
Update axis for `22.06`

### DIFF
--- a/ci/axis/nightly-env-arm64.yaml
+++ b/ci/axis/nightly-env-arm64.yaml
@@ -7,6 +7,7 @@ CONDA_CONFIG_FILE:
 # Use M.X.Ya (major.minor.patch) with 'a' version to match nightly tag
 RAPIDS_VER:
   - 22.04.00a
+  - 22.06.00a
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/nightly-env.yaml
+++ b/ci/axis/nightly-env.yaml
@@ -7,6 +7,7 @@ CONDA_CONFIG_FILE:
 # Use M.X.Ya (major.minor.patch) with 'a' version to match nightly tag
 RAPIDS_VER:
   - 22.04.00a
+  - 22.06.00a
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:


### PR DESCRIPTION
This PR updates the axis files to generate `22.06` `env` packages.