### PR TITLE
Update `bokeh` version

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -31,7 +31,7 @@ benchmark_version:
 black_version:
   - '=19.10'
 bokeh_version:
-  - '>=2.3.2,<2.4'
+  - '>=2.4.2,<=2.5'
 boost_cpp_version:
   - '=1.72.0'
 clang_version:


### PR DESCRIPTION
This PR updates the `bokeh` version to align with https://github.com/rapidsai/cuxfilter/pull/355.