### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -79,6 +79,7 @@ requirements:
     - gmock {{ gmock_version }}
     - graphviz
     - gtest {{ gtest_version }}
+    - h5py
     - hdbscan
     - holoviews {{ holoviews_version }}
     - httpretty

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -31,7 +31,7 @@ benchmark_version:
 black_version:
   - '=19.10'
 bokeh_version:
-  - '>=2.3.2,<2.4'
+  - '>=2.4.2,<=2.5'
 boost_cpp_version:
   - '=1.72.0'
 clang_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.