### PR TITLE
Revert "Update axis for `22.06`"

### DIFF
--- a/ci/axis/nightly-env-arm64.yaml
+++ b/ci/axis/nightly-env-arm64.yaml
@@ -7,7 +7,6 @@ CONDA_CONFIG_FILE:
 # Use M.X.Ya (major.minor.patch) with 'a' version to match nightly tag
 RAPIDS_VER:
   - 22.04.00a
-  - 22.06.00a
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/nightly-env.yaml
+++ b/ci/axis/nightly-env.yaml
@@ -7,7 +7,6 @@ CONDA_CONFIG_FILE:
 # Use M.X.Ya (major.minor.patch) with 'a' version to match nightly tag
 RAPIDS_VER:
   - 22.04.00a
-  - 22.06.00a
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:


### PR DESCRIPTION
This reverts commit c3dafda5fdc7639d49c3197133d6e3e3ca493d2f.

There is already a `branch-22.06` with the correct axis values for this repository. The Jenkins job for that branch was misconfigured and was building `branch-22.04` which is why the `22.06` packages never got published correctly.