### PR TITLE
Pin click version to last supported by black 22.1.0.

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - automake
     - benchmark {{ benchmark_version }}
     - black {{ black_version }}
+    - click =8.0.4  # Required for black < 22.3.0, see https://github.com/psf/black/issues/2964
     - conda-forge::blas
     - boost
     - boost-cpp {{ boost_cpp_version }}


### PR DESCRIPTION
Our 22.04 will continue using black < 22.3.0, so we need the appropriate Click pinning to make sure that black continues to work.