### PR TITLE
Remove now unnecessary click pinning.

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -43,7 +43,6 @@ requirements:
     - automake
     - benchmark {{ benchmark_version }}
     - black {{ black_version }}
-    - click =8.0.4  # Required for black < 22.3.0, see https://github.com/psf/black/issues/2964
     - conda-forge::blas
     - boost
     - boost-cpp {{ boost_cpp_version }}


### PR DESCRIPTION
Removes the pinning introduced in #453 on branch 22.06 since that pinning was specifically needed only for branch-22.04.