### PR TITLE
Add `dask`/`distributed` version specs to `rapids-notebook-env`

### DIFF
--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -42,9 +42,11 @@ requirements:
     - cudatoolkit ={{ cuda_major }}.*
     - cupy {{ cupy_version }}
     - cython {{ cython_version }}
+    - dask {{ dask_version }}
     - dask-labextension
     - dask-ml
     - datashader {{ datashader_version }}
+    - distributed {{ distributed_version }}
     - filterpy
     - holoviews
     - ipython {{ ipython_version }}


### PR DESCRIPTION
This PR adds `dask`/`distributed` version specs to the `rapids-notebook-env` to ensure that the RAPIDS supported versions of these packages are installed. This should resolve an issue in our child `rapidsai/docker` images where older versions of `dask-cudf`/`cudf`/`libcudf` were being installed due to mismatched version specifications for these packages.