### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -42,9 +42,11 @@ requirements:
     - cudatoolkit ={{ cuda_major }}.*
     - cupy {{ cupy_version }}
     - cython {{ cython_version }}
+    - dask {{ dask_version }}
     - dask-labextension
     - dask-ml
     - datashader {{ datashader_version }}
+    - distributed {{ distributed_version }}
     - filterpy
     - holoviews
     - ipython {{ ipython_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -123,7 +123,7 @@ pandas_version:
 pandoc_version:
   - '<=2.0.0'
 panel_version:
-  - '>=0.10.3'
+  - '>=0.12.7,<0.13'
 pillow_version:
   - '>=9.0.0'
 pydeck_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.