### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -42,9 +42,11 @@ requirements:
     - cudatoolkit ={{ cuda_major }}.*
     - cupy {{ cupy_version }}
     - cython {{ cython_version }}
+    - dask {{ dask_version }}
     - dask-labextension
     - dask-ml
     - datashader {{ datashader_version }}
+    - distributed {{ distributed_version }}
     - filterpy
     - holoviews
     - ipython {{ ipython_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -51,7 +51,7 @@ cython_version:
 dask_version:
   - '=2022.03.0'
 datashader_version:
-  - '>0.12,<=0.13'
+  - '>0.13,<0.14'
 distributed_version:
   - '=2022.03.0'
 dlpack_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.