### PR TITLE
Allow CMake 3.23 (just exclude 3.23.0)

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -37,7 +37,7 @@ boost_cpp_version:
 clang_version:
   - '=11.1.0'
 cmake_version:
-  - '>=3.20.1,<3.21'
+  - '>=3.20.1,!=3.23.0'
 cmake_format_version:
   - '=0.6.11'
 cmake_setuptools_version:


### PR DESCRIPTION
As CMake 3.23.1 fixes the issue seen in 3.23.0, adjust the constraint here to allow 3.23.1 to be installed.