### PR TITLE
Fix integration tests

### DIFF
--- a/ci/test/integration.sh
+++ b/ci/test/integration.sh
@@ -16,9 +16,6 @@ export TESTRESULTS_DIR="$WORKSPACE/testresults"
 mkdir -p ${TESTRESULTS_DIR}
 SUITEERROR=0
 
-gpuci_logger "Install conda packages needed by tests in rapids environment"
-gpuci_conda_retry --condaretry_max_retries=10 install -y --freeze-installed requests
-
 gpuci_logger "Run Python tests"
 py.test --junitxml=${TESTRESULTS_DIR}/pytest.xml -v "$WORKSPACE/test"
 exitcode=$?


### PR DESCRIPTION
This PR removes a step to install `requests`. `requests` is already available in our images and this step seems to be causing `conda` solve issues.

Ultimately these integration tests should eventually be removed from this repository, but this should at least get them working again for now.