### PR TITLE
Require UCX 1.12.1+

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -151,7 +151,7 @@ requirements:
     - twine
     - typing_extensions
     - ucx-proc=*=gpu
-    - ucx
+    - ucx {{ ucx_version }}
     - umap-learn
 
 about:

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -150,8 +150,8 @@ requirements:
     - treelite {{ treelite_version }}
     - twine
     - typing_extensions
-    - ucx-proc=*=gpu
-    - ucx {{ ucx_version }}
+    - conda-forge::ucx-proc=*=gpu
+    - conda-forge::ucx {{ ucx_version }}
     - umap-learn
 
 about:

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -60,6 +60,8 @@ requirements:
     - pylibcugraph ={{ minor_version }}.*
     - libcugraph_etl ={{ minor_version }}.*
     - ptxcompiler  # [linux64]  # CUDA enhanced compat. See https://github.com/rapidsai/ptxcompiler
+    - conda-forge::ucx-proc=*=gpu
+    - conda-forge::ucx {{ ucx_version }}
 
 test:              # [linux64]
   imports:         # [linux64]

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -167,3 +167,5 @@ treelite_version:
   - '=2.3.0'
 transformers_version:
   - '<=4.10.3'
+ucx_version:
+  - '>=1.12.1'


### PR DESCRIPTION
In addition to being a recent UCX release, these packages come from conda-forge instead of RAPIDS, which is where those packages will come from going forward.