### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -13,9 +13,9 @@ xgboost_version:
 
 # Versions for conda
 conda_version:
-  - '=4.10.3'
+  - '=4.12.0'
 conda_build_version:
-  - '=3.21.7'
+  - '=3.21.8'
 conda_verify_version:
   - '=3.1.1'
 

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -164,7 +164,7 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=2.3.0'
+  - '=2.4.0'
 transformers_version:
   - '<=4.10.3'
 ucx_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.