### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -49,11 +49,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '>=2022.03.0'
+  - '=2022.05.1'
 datashader_version:
   - '>0.13,<0.14'
 distributed_version:
-  - '>=2022.03.0'
+  - '=2022.05.1'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -164,7 +164,7 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=2.3.0'
+  - '=2.4.0'
 transformers_version:
   - '<=4.10.3'
 ucx_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.