### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -31,6 +31,8 @@ build:
     - CUDA_VERSION
     - RAPIDS_VER
     - VERSION_SUFFIX
+  ignore_run_exports_from:
+    - nvcc_{{ target_platform }}
 
 requirements:
   host:
@@ -59,6 +61,9 @@ requirements:
     - cuda-python {{ cuda_python_version }}
     - cudatoolkit ={{ cuda_major }}.*
     - cupy {{ cupy_version }}
+    - c-compiler
+    - cxx-compiler
+    - gcc_impl_{{ target_platform }}  {{ gcc_version }}
     - cython {{ cython_version }}
     - dask {{ dask_version }}
     - dask-ml
@@ -87,11 +92,8 @@ requirements:
     - isort {{ isort_version }}
     - lapack
     - libcypher-parser
-    - libgcc-ng {{ build_stack_version }}
-    - libgfortran-ng {{ build_stack_version }}
     - liblapack
     - librdkafka {{ librdkafka_version }}
-    - libstdcxx-ng {{ build_stack_version }}
     - libtool
     - libwebp
     - lightgbm
@@ -106,6 +108,7 @@ requirements:
     - nltk
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}
+    - nvcc_{{ target_platform }} ={{ cuda_major }}.*
     - nvtx {{ nvtx_version }}
     - openslide
     - packaging
@@ -146,6 +149,7 @@ requirements:
     - spdlog {{ spdlog_version }}
     - statsmodels
     - streamz
+    - sysroot_{{ target_platform }} {{ sysroot_version }}
     - transformers {{ transformers_version }}
     - treelite {{ treelite_version }}
     - twine

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -135,7 +135,7 @@ python_confluent_kafka_version:
 pytorch_version:
   - '>=1.6'
 protobuf_version:
-  - '>=3.4.1,<4.0.0'
+  - '>=3.20.1,<3.21.0a0'
 pydata_sphinx_theme_version:
   - '>=0.6.3'
 pyproj_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -49,11 +49,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '=2022.05.1'
+  - '=2022.05.2'
 datashader_version:
   - '>0.13,<0.14'
 distributed_version:
-  - '=2022.05.1'
+  - '=2022.05.2'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -49,11 +49,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '>=2022.03.0'
+  - '=2022.05.1'
 datashader_version:
   - '>0.13,<0.14'
 distributed_version:
-  - '>=2022.03.0'
+  - '=2022.05.1'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -19,9 +19,11 @@ conda_build_version:
 conda_verify_version:
   - '=3.1.1'
 
-# Versions for `libgcc-ng`, `libgfortran-ng`, `libstdcxx-ng` stack
-build_stack_version:
-  - '>=9.4.0'
+# conda compilers
+gcc_version:
+  - 9
+sysroot_version:
+  - "2.17"
 
 # Shared versions across meta-pkgs
 arrow_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -164,7 +164,7 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=2.3.0'
+  - '=2.4.0'
 transformers_version:
   - '<=4.10.3'
 ucx_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.