### PR TITLE
Remove `nvcc` from `22.06`

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -31,8 +31,6 @@ build:
     - CUDA_VERSION
     - RAPIDS_VER
     - VERSION_SUFFIX
-  ignore_run_exports_from:
-    - nvcc_{{ target_platform }}
 
 requirements:
   host:
@@ -108,7 +106,6 @@ requirements:
     - nltk
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}
-    - nvcc_{{ target_platform }} ={{ cuda_major }}.*
     - nvtx {{ nvtx_version }}
     - openslide
     - packaging


### PR DESCRIPTION
This package removes `nvcc` from `rapids-build-env`, which was causing issues with our CI and end-user images.