### PR TITLE
Add pytest-cases to environment.

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -127,6 +127,7 @@ requirements:
     - pytest
     - pytest-asyncio {{ pytest_asyncio_version }}
     - pytest-benchmark
+    - pytest-cases
     - pytest-cov
     - pytest-timeout
     - pytest-xdist


### PR DESCRIPTION
This pytest plugin is needed for the new benchmarks in cudf and will be used by tests in the future.