### PR TITLE
Force install cuda-python from conda-forge channel

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -56,7 +56,7 @@ requirements:
     - conda {{ conda_version }}
     - conda-build {{ conda_build_version }}
     - conda-verify {{ conda_verify_version }}
-    - cuda-python {{ cuda_python_version }}
+    - conda-forge::cuda-python {{ cuda_python_version }}
     - cudatoolkit ={{ cuda_major }}.*
     - cupy {{ cupy_version }}
     - c-compiler

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -36,7 +36,7 @@ requirements:
   host:
     - python
   run:
-    - cuda-python {{ cuda_python_version }}
+    - conda-forge::cuda-python {{ cuda_python_version }}
     - cudatoolkit ={{ cuda_major }}.*
     - cupy {{ cupy_version }}
     - nccl {{ nccl_version }}


### PR DESCRIPTION
The latest version of the `cuda-python` package published on the `nvidia` conda channel has a dependency on `cuda-toolkit` instead of `cudatoolkit` which is bringing a lot of packages like `cuda-nvcc` which are breaking our builds for now. We are forcing the install of `cuda-python` from the `conda-forge` channel to prevent this for now