### PR TITLE
Set upper bound version to 1.7.0 for cuda-python

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -56,7 +56,7 @@ requirements:
     - conda {{ conda_version }}
     - conda-build {{ conda_build_version }}
     - conda-verify {{ conda_verify_version }}
-    - conda-forge::cuda-python {{ cuda_python_version }}
+    - cuda-python {{ cuda_python_version }}
     - cudatoolkit ={{ cuda_major }}.*
     - cupy {{ cupy_version }}
     - c-compiler

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -36,7 +36,7 @@ requirements:
   host:
     - python
   run:
-    - conda-forge::cuda-python {{ cuda_python_version }}
+    - cuda-python {{ cuda_python_version }}
     - cudatoolkit ={{ cuda_major }}.*
     - cupy {{ cupy_version }}
     - nccl {{ nccl_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -45,7 +45,7 @@ cmakelang_version:
 cmake_setuptools_version:
   - '>=0.1.3'
 cuda_python_version:
-  - '>=11.5,<12'
+  - '>=11.5,<11.7.1'
 cupy_version:
   - '>=9.5.0,<11.0.0a0'
 cython_version:


### PR DESCRIPTION
`conda` do not keep the channel specification while creating the list of dependencies in the final package, so to fix the `cuda-python` issue, we need to prevent installing `cuda-python>11.7.0`