### PR TITLE
Pin `cuda-python` to `conda-forge` channel

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -56,7 +56,7 @@ requirements:
     - conda {{ conda_version }}
     - conda-build {{ conda_build_version }}
     - conda-verify {{ conda_verify_version }}
-    - cuda-python {{ cuda_python_version }}
+    - conda-forge::cuda-python {{ cuda_python_version }}
     - cudatoolkit ={{ cuda_major }}.*
     - cupy {{ cupy_version }}
     - c-compiler

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -36,7 +36,7 @@ requirements:
   host:
     - python
   run:
-    - cuda-python {{ cuda_python_version }}
+    - conda-forge::cuda-python {{ cuda_python_version }}
     - cudatoolkit ={{ cuda_major }}.*
     - cupy {{ cupy_version }}
     - nccl {{ nccl_version }}


### PR DESCRIPTION
This PR pins `cuda-python` to `conda-forge` channel