### PR TITLE
Update isort version.

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -87,7 +87,7 @@ holoviews_version:
 ipython_version:
   - '=7.31.1'
 isort_version:
-  - '=5.6.4'
+  - '=5.10.1'
 jupyterlab_version:
   - '>=3.1.4,<4.0a0'
 jupyter_packaging_version:


### PR DESCRIPTION
This update allows us to use multiple separate configuration files, which is useful for cudf. I'm opening PRs for all other RAPIDS repos right now, but based on local runs no code changes are needed for this update.