### PR TITLE
Pin `pytorch` temporarily to avoid `libcupti` errors

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -135,7 +135,7 @@ pydocstyle_version:
 python_confluent_kafka_version:
   - '>=1.3.0'
 pytorch_version:
-  - '>=1.6'
+  - '>=1.6,<1.12.0'
 protobuf_version:
   - '>=3.20.1,<3.21.0a0'
 pydata_sphinx_theme_version:


### PR DESCRIPTION
Required for: https://github.com/rapidsai/cudf/pull/11289