### PR TITLE
Pin markdown<3.4.0 to avoid sphinx-markdown-tables bug

### DIFF
--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - doxygen {{ doxygen_version }}
     - html5lib
     - jupyter_sphinx
-    - markdown
+    - markdown {{ markdown_version }}
     - nbsphinx {{ nbsphinx_version }}
     - numpydoc
     - pandoc {{ pandoc_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -94,6 +94,8 @@ jupyter_packaging_version:
   - '>=0.7.0,<0.8'
 librdkafka_version:
   - '=1.7.*'
+markdown_version:
+  - '<3.4.0'
 mimesis_version:
   - '<4.1'
 moto_version:


### PR DESCRIPTION
sphinx-markdown-tables has an error with Markdown>3.4.0 releases: https://github.com/ryanfox/sphinx-markdown-tables/issues/36 , causing trouble in various RAPIDS project doc CI

Pin markdown<3.4.0 to sidestep this issue.