### PR TITLE
Remove `arrow-cpp-proc`

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -37,7 +37,6 @@ requirements:
     - python
   run:
     - arrow-cpp {{ arrow_version }}
-    - arrow-cpp-proc * cuda
     - asvdb
     - autoconf
     - automake


### PR DESCRIPTION
Similarly to https://github.com/rapidsai/cudf/pull/10995, this PR removes `arrow-cpp-proc * cuda` from our list of dependencies.