### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.10 [skip gpuci]

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -37,7 +37,6 @@ requirements:
     - python
   run:
     - arrow-cpp {{ arrow_version }}
-    - arrow-cpp-proc * cuda
     - asvdb
     - autoconf
     - automake

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -154,6 +154,7 @@ requirements:
     - conda-forge::ucx-proc=*=gpu
     - conda-forge::ucx {{ ucx_version }}
     - umap-learn
+    - werkzeug {{ werkzeug_version }} # Temporary transient dependency pinning to avoid URL-LIB3 + moto timeouts
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - doxygen {{ doxygen_version }}
     - html5lib
     - jupyter_sphinx
-    - markdown
+    - markdown {{ markdown_version }}
     - nbsphinx {{ nbsphinx_version }}
     - numpydoc
     - pandoc {{ pandoc_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -173,3 +173,5 @@ transformers_version:
   - '<=4.10.3'
 ucx_version:
   - '>=1.12.1'
+werkzeug_version:
+  - '<2.2.0'

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -94,6 +94,8 @@ jupyter_packaging_version:
   - '>=0.7.0,<0.8'
 librdkafka_version:
   - '=1.7.*'
+markdown_version:
+  - '<3.4.0'
 mimesis_version:
   - '<4.1'
 moto_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.