### PR TITLE
Allow CuPy 11

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -47,7 +47,7 @@ cmake_setuptools_version:
 cuda_python_version:
   - '>=11.5,<11.7.1'
 cupy_version:
-  - '>=9.5.0,<11.0.0a0'
+  - '>=9.5.0,<12.0.0a0'
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:


### PR DESCRIPTION
As CuPy 11 is now available and may be needed in some cases, relax this bound to allow CuPy 11.