### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.10 [skip gpuci]

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -154,6 +154,7 @@ requirements:
     - conda-forge::ucx-proc=*=gpu
     - conda-forge::ucx {{ ucx_version }}
     - umap-learn
+    - werkzeug {{ werkzeug_version }} # Temporary transient dependency pinning to avoid URL-LIB3 + moto timeouts
 
 about:
   home: http://rapids.ai/

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -113,7 +113,7 @@ networkx_version:
 nlohmann_json_version:
   - '3.9.1'
 nodejs_version:
-  - '>=12,<15'
+  - '>=14'
 numba_version:
   - '>=0.54'
 numpy_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -173,3 +173,5 @@ transformers_version:
   - '<=4.10.3'
 ucx_version:
   - '>=1.12.1'
+werkzeug_version:
+  - '<2.2.0'

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -47,7 +47,7 @@ cmake_setuptools_version:
 cuda_python_version:
   - '>=11.5,<11.7.1'
 cupy_version:
-  - '>=9.5.0,<11.0.0a0'
+  - '>=9.5.0,<12.0.0a0'
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.