### PR TITLE
[REVIEW] Relax arrow version pinning to `8.x`

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -27,7 +27,7 @@ sysroot_version:
 
 # Shared versions across meta-pkgs
 arrow_version:
-  - '=8.0.0'
+  - '=8'
 benchmark_version:
   - '=1.5.1'
 black_version:


### PR DESCRIPTION
Changes to be similar to: https://github.com/rapidsai/cudf/pull/11412/