### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.10 [skip gpuci]

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -73,7 +73,7 @@ fsspec_version:
 gdal_version:
   - '>=3.3.0,<3.4.0a0'
 geopandas_version:
-  - '>=0.9.0,<0.10.0a0'
+  - '>=0.11.0'
 gcsfs_version:
   - '>=0.8.0'
 google_cloud_cpp_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -51,11 +51,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '>=2022.05.2'
+  - '==2022.7.1'
 datashader_version:
   - '>0.13,<0.14'
 distributed_version:
-  - '>=2022.05.2'
+  - '==2022.7.1'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -47,7 +47,7 @@ cmake_setuptools_version:
 cuda_python_version:
   - '>=11.5,<11.7.1'
 cupy_version:
-  - '>=9.5.0,<11.0.0a0'
+  - '>=9.5.0,<12.0.0a0'
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -27,7 +27,7 @@ sysroot_version:
 
 # Shared versions across meta-pkgs
 arrow_version:
-  - '=8.0.0'
+  - '=8'
 benchmark_version:
   - '=1.5.1'
 black_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.