### PR TITLE
[REVIEW] Update `markdown` pinning to fix issues during docs build

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -95,7 +95,7 @@ jupyter_packaging_version:
 librdkafka_version:
   - '=1.7.*'
 markdown_version:
-  - '<3.4.0'
+  - '>=3.4.1'
 mimesis_version:
   - '<4.1'
 moto_version:


### PR DESCRIPTION
After https://github.com/rapidsai/integration/pull/503 was merged, the issue was fixed and a newer version of `markdown=3.4.1` was released with fixes, this version is also required to fix the following error we see in docs-build:
```python
Extension error (sphinx_markdown_tables):
Handler <function process_tables at 0x7fdc0416a040> for event 'source-read' threw an exception (exception: __init__() takes 2 positional arguments but 3 were given)
make: *** [Makefile:20: html] Error 2
```