### PR TITLE
Bump `gdal` version

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -33,7 +33,7 @@ source activate base
 env
 
 # Install gpuCI tools
-conda install -y -c gpuci gpuci-tools
+conda install -y --channel gpuci gpuci-tools boa
 
 # Print diagnostic information
 gpuci_logger "Print conda info..."
@@ -52,8 +52,14 @@ ARCH=$(uname -m)
 function build_pkg {
   # Build pkg
   gpuci_logger "Start conda build for '${1}'..."
-  gpuci_conda_retry build --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge \
-    --python=${PYTHON_VER} -m ${CONDA_CONFIG_FILE} ${1}
+  gpuci_conda_retry mambabuild \
+    --override-channels \
+    --channel ${CONDA_USERNAME:-rapidsai-nightly} \
+    --channel nvidia \
+    --channel conda-forge \
+    --python=${PYTHON_VER} \
+    --variant-config-files ${CONDA_CONFIG_FILE} \
+    ${1}
 }
 
 function run_builds {

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -71,7 +71,7 @@ flake8_version:
 fsspec_version:
   - '>=0.9.0'
 gdal_version:
-  - '>=3.3.0,<3.4.0a0'
+  - '>=3.4.3,<3.4.4a0'
 geopandas_version:
   - '>=0.11.0'
 gcsfs_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -35,7 +35,7 @@ black_version:
 bokeh_version:
   - '>=2.4.2,<=2.5'
 boost_cpp_version:
-  - '=1.72.0'
+  - '=1.74.0'
 clang_version:
   - '=11.1.0'
 cmake_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -143,7 +143,7 @@ protobuf_version:
 pydata_sphinx_theme_version:
   - '>=0.6.3'
 pyproj_version:
-  - '>=2.4,<=3.1'
+  - '>=2.4,<=3.4'
 pyppeteer_version:
   - '>=0.2.6'
 pytest_asyncio_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -71,7 +71,7 @@ flake8_version:
 fsspec_version:
   - '>=0.9.0'
 gdal_version:
-  - '>=3.4.3,<3.4.4a0'
+  - '>=3.5.1,<3.5.2a0'
 geopandas_version:
   - '>=0.11.0'
 gcsfs_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -71,7 +71,7 @@ flake8_version:
 fsspec_version:
   - '>=0.9.0'
 gdal_version:
-  - '>=3.5.1,<3.5.2a0'
+  - '>=3.4.3,<3.4.4a0'
 geopandas_version:
   - '>=0.11.0'
 gcsfs_version:


### PR DESCRIPTION
This PR bumps the version of `gdal` that's being used in an attempt to resolve some conda-solve issue in our images.

It also switches our builds to use `mambabuild` to circumvent this `conda build` bug that we ran into: https://github.com/conda/conda-build/issues/4498.