### PR TITLE
[gpuCI] Forward-merge branch-22.08 to branch-22.10 [skip gpuci]

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -33,7 +33,7 @@ source activate base
 env
 
 # Install gpuCI tools
-conda install -y -c gpuci gpuci-tools
+conda install -y --channel gpuci gpuci-tools boa
 
 # Print diagnostic information
 gpuci_logger "Print conda info..."
@@ -52,8 +52,14 @@ ARCH=$(uname -m)
 function build_pkg {
   # Build pkg
   gpuci_logger "Start conda build for '${1}'..."
-  gpuci_conda_retry build --override-channels -c ${CONDA_USERNAME:-rapidsai-nightly} -c nvidia -c conda-forge \
-    --python=${PYTHON_VER} -m ${CONDA_CONFIG_FILE} ${1}
+  gpuci_conda_retry mambabuild \
+    --override-channels \
+    --channel ${CONDA_USERNAME:-rapidsai-nightly} \
+    --channel nvidia \
+    --channel conda-forge \
+    --python=${PYTHON_VER} \
+    --variant-config-files ${CONDA_CONFIG_FILE} \
+    ${1}
 }
 
 function run_builds {

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -155,7 +155,7 @@ s3fs_version:
 scikit_build_version:
   - '=0.13.1'
 scikit_image_version:
-  - '>=0.18.0,<0.20.0'
+  - '>=0.19.0,<0.20.0'
 scikit_learn_version:
   - '=0.24'
 # when scipy is updated, remove upper bound on networkx ver.

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -35,7 +35,7 @@ black_version:
 bokeh_version:
   - '>=2.4.2,<=2.5'
 boost_cpp_version:
-  - '=1.72.0'
+  - '=1.74.0'
 clang_version:
   - '=11.1.0'
 cmake_version:
@@ -71,7 +71,7 @@ flake8_version:
 fsspec_version:
   - '>=0.9.0'
 gdal_version:
-  - '>=3.3.0,<3.4.0a0'
+  - '>=3.4.3,<3.4.4a0'
 geopandas_version:
   - '>=0.11.0'
 gcsfs_version:
@@ -143,7 +143,7 @@ protobuf_version:
 pydata_sphinx_theme_version:
   - '>=0.6.3'
 pyproj_version:
-  - '>=2.4,<=3.1'
+  - '>=2.4,<=3.4'
 pyppeteer_version:
   - '>=0.2.6'
 pytest_asyncio_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.08` that creates a PR to keep `branch-22.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.