### PR TITLE
Upgrade to Treelite 3.0.0

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -168,7 +168,7 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=2.4.0'
+  - '=3.0.0'
 transformers_version:
   - '<=4.10.3'
 ucx_version:


### PR DESCRIPTION
Required by https://github.com/rapidsai/cuml/pull/4885. See the CI result in https://github.com/rapidsai/cuml/pull/4885 which is testing cuML with Treelite 3.0.0.