### PR TITLE
Trying to resolve a version issue with GDAL and TensorFlow, cuXFilter, etc.

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -71,7 +71,7 @@ flake8_version:
 fsspec_version:
   - '>=0.9.0'
 gdal_version:
-  - '>=3.0.0'
+  - '>=3.5.0'
 geopandas_version:
   - '>=0.11.0'
 gcsfs_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -71,7 +71,7 @@ flake8_version:
 fsspec_version:
   - '>=0.9.0'
 gdal_version:
-  - '>=3.3.0,<3.4.0a0'
+  - '>=3.0.0'
 geopandas_version:
   - '>=0.11.0'
 gcsfs_version:


### PR DESCRIPTION
cuspatial has GDAL pinned to 3.4.x which is causing a conflict with https://github.com/rapidsai/cuspatial/issues/674 . I'm updating here and cuspatial to use 3.*. Contributes to https://github.com/rapidsai/cuspatial/issues/674 