### PR TITLE
Upgrade minimum numba version to `0.56.2`

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -115,7 +115,7 @@ nlohmann_json_version:
 nodejs_version:
   - '>=14'
 numba_version:
-  - '>=0.54'
+  - '>=0.56.2'
 numpy_version:
   - '>=1.19'
 nvtx_version:


### PR DESCRIPTION
Required for https://github.com/rapidsai/cudf/pull/11701/