### PR TITLE
[gpuCI] Forward-merge branch-22.10 to branch-22.12 [skip gpuci]

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -123,7 +123,7 @@ nvtx_version:
 openjdk_version:
   - '>=8.0'
 pandas_version:
-  - '>=1.0,<1.5.0dev0'
+  - '>=1.0,<1.6.0dev0'
 pandoc_version:
   - '<=2.0.0'
 panel_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -115,7 +115,7 @@ nlohmann_json_version:
 nodejs_version:
   - '>=14'
 numba_version:
-  - '>=0.54'
+  - '>=0.56.2'
 numpy_version:
   - '>=1.19'
 nvtx_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.10` that creates a PR to keep `branch-22.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.