### PR TITLE
[gpuCI] Forward-merge branch-22.10 to branch-22.12 [skip gpuci]

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -51,11 +51,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '==2022.9.1'
+  - '>=2022.7.1'
 datashader_version:
   - '>0.13,<0.14'
 distributed_version:
-  - '==2022.9.1'
+  - '>=2022.7.1'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -51,11 +51,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '>=2022.7.1'
+  - '==2022.9.2'
 datashader_version:
   - '>0.13,<0.14'
 distributed_version:
-  - '>=2022.7.1'
+  - '==2022.9.2'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.10` that creates a PR to keep `branch-22.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.