### PR TITLE
Req `pip` & `tomli`

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -148,6 +148,7 @@ requirements:
     - statsmodels
     - streamz
     - sysroot_{{ target_platform }} {{ sysroot_version }}
+    - tomli  # [py<311]
     - transformers {{ transformers_version }}
     - treelite {{ treelite_version }}
     - twine

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -111,6 +111,7 @@ requirements:
     - pandas {{ pandas_version }}
     - panel {{ panel_version }}
     - pillow {{ pillow_version }}
+    - pip
     - pkg-config
     - pre-commit
     - protobuf {{ protobuf_version }}


### PR DESCRIPTION
Require `pip` for building and installing. Also require `tomli` for TOML parsing in Python pre-3.11.