### PR TITLE
Bump patch version for 22.10

### DIFF
--- a/ci/axis/release-arm64.yaml
+++ b/ci/axis/release-arm64.yaml
@@ -6,7 +6,7 @@ CONDA_CONFIG_FILE:
 
 # Use M.X.Y (major.minor.patch) version to match tag
 RAPIDS_VER:
-  - "22.10.00"
+  - "22.10.01"
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -6,7 +6,7 @@ CONDA_CONFIG_FILE:
 
 # Use M.X.Y (major.minor.patch) version to match tag
 RAPIDS_VER:
-  - "22.10.00"
+  - "22.10.01"
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -52,15 +52,27 @@ ARCH=$(uname -m)
 function build_pkg {
   # Build pkg
   gpuci_logger "Start conda build for '${1}'..."
-  gpuci_conda_retry mambabuild \
-    --override-channels \
-    --channel conda-forge \
-    --channel rapidsai \
-    --channel rapidsai-nightly \
-    --channel nvidia \
-    --python=${PYTHON_VER} \
-    --variant-config-files ${CONDA_CONFIG_FILE} \
-    ${1}
+  # Only include rapidsai-nightly for nightly builds
+  if [[ "$BUILD_MODE" = "branch" && "$SOURCE_BRANCH" = "main" ]] ; then
+    gpuci_conda_retry mambabuild \
+      --override-channels \
+      --channel conda-forge \
+      --channel rapidsai \
+      --channel nvidia \
+      --python=${PYTHON_VER} \
+      --variant-config-files ${CONDA_CONFIG_FILE} \
+      ${1}
+    else
+      gpuci_conda_retry mambabuild \
+      --override-channels \
+      --channel conda-forge \
+      --channel rapidsai \
+      --channel rapidsai-nightly \
+      --channel nvidia \
+      --python=${PYTHON_VER} \
+      --variant-config-files ${CONDA_CONFIG_FILE} \
+      ${1}
+    fi
 }
 
 function run_builds {

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -54,9 +54,10 @@ function build_pkg {
   gpuci_logger "Start conda build for '${1}'..."
   gpuci_conda_retry mambabuild \
     --override-channels \
-    --channel ${CONDA_USERNAME:-rapidsai-nightly} \
-    --channel nvidia \
     --channel conda-forge \
+    --channel rapidsai \
+    --channel rapidsai-nightly \
+    --channel nvidia \
     --python=${PYTHON_VER} \
     --variant-config-files ${CONDA_CONFIG_FILE} \
     ${1}


### PR DESCRIPTION
Need to do this so so that the cuda-python version (https://github.com/rapidsai/integration/pull/549) is released in the meta and env packages.