### PR TITLE
Add `versioneer` to build dependencies

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -157,6 +157,7 @@ requirements:
     - conda-forge::ucx-proc=*=gpu
     - conda-forge::ucx {{ ucx_version }}
     - umap-learn
+    - versioneer {{ versioneer_version }}
     - werkzeug {{ werkzeug_version }} # Temporary transient dependency pinning to avoid URL-LIB3 + moto timeouts
 
 about:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -173,5 +173,7 @@ transformers_version:
   - '<=4.10.3'
 ucx_version:
   - '>=1.12.1'
+versioneer_version:
+  - '>=0.24'
 werkzeug_version:
   - '<2.2.0'


### PR DESCRIPTION
As it is easier to upgrade `versioneer` when it is devendored and it works better with `pyproject.toml`, add `versioneer` as a build dependency to service libraries moving in this direction.