### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -157,6 +157,7 @@ requirements:
     - conda-forge::ucx-proc=*=gpu
     - conda-forge::ucx {{ ucx_version }}
     - umap-learn
+    - versioneer {{ versioneer_version }}
     - werkzeug {{ werkzeug_version }} # Temporary transient dependency pinning to avoid URL-LIB3 + moto timeouts
 
 about:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -15,7 +15,7 @@ xgboost_version:
 conda_version:
   - '=4.12.0'
 conda_build_version:
-  - '=3.21.8'
+  - '=3.22.0'
 conda_verify_version:
   - '=3.1.1'
 

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -173,5 +173,7 @@ transformers_version:
   - '<=4.10.3'
 ucx_version:
   - '>=1.12.1'
+versioneer_version:
+  - '>=0.24'
 werkzeug_version:
   - '<2.2.0'


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.