### PR TITLE
Reorder channel priority.

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -55,8 +55,8 @@ function build_pkg {
   gpuci_conda_retry mambabuild \
     --override-channels \
     --channel ${CONDA_USERNAME:-rapidsai-nightly} \
-    --channel nvidia \
     --channel conda-forge \
+    --channel nvidia \
     --python=${PYTHON_VER} \
     --variant-config-files ${CONDA_CONFIG_FILE} \
     ${1}


### PR DESCRIPTION
Puts the priority of the `nvidia` channel below `conda-forge` for consistency with changes for the 22.10.01 hotfix.