### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -51,11 +51,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '>=2022.9.2'
+  - '==2022.11.0'
 datashader_version:
   - '>0.13,<0.14'
 distributed_version:
-  - '>=2022.9.2'
+  - '==2022.11.0'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -15,7 +15,7 @@ xgboost_version:
 conda_version:
   - '=4.12.0'
 conda_build_version:
-  - '=3.21.8'
+  - '=3.22.0'
 conda_verify_version:
   - '=3.1.1'
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.