### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -55,8 +55,8 @@ function build_pkg {
   gpuci_conda_retry mambabuild \
     --override-channels \
     --channel ${CONDA_USERNAME:-rapidsai-nightly} \
-    --channel nvidia \
     --channel conda-forge \
+    --channel nvidia \
     --python=${PYTHON_VER} \
     --variant-config-files ${CONDA_CONFIG_FILE} \
     ${1}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -51,11 +51,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '>=2022.9.2'
+  - '==2022.11.0'
 datashader_version:
   - '>0.13,<0.14'
 distributed_version:
-  - '>=2022.9.2'
+  - '==2022.11.0'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.