### PR TITLE
Update `cmake` pinning to avoid FindCUDAToolkit bug

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -39,7 +39,7 @@ boost_cpp_version:
 clang_version:
   - '=11.1.0'
 cmake_version:
-  - '>=3.20.1,!=3.23.0'
+  - '>=3.23.1,!=3.25.0'
 cmakelang_version:
   - '=0.6.13'
 cmake_setuptools_version:


### PR DESCRIPTION
This PR updates `cmake` pinnings to avoid `FindCUDAToolkit` bug as in: https://github.com/rapidsai/cudf/pull/12188/
This PR also updates the minimum `cmake` version to `3.23.1`, since `kvikio` is the only one left to be using older cmake version which is being upgraded in: https://github.com/rapidsai/kvikio/pull/147