### PR TITLE
Upgrade to Treelite 3.0.1

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -168,7 +168,7 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=3.0.0'
+  - '=3.0.1'
 transformers_version:
   - '<=4.10.3'
 ucx_version:


### PR DESCRIPTION
Required by rapidsai/cuml#5018. See the CI result in  rapidsai/cuml#5018 which is testing cuML with Treelite 3.0.1.