### PR TITLE
Pin `dask` and `distributed` for release 

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -51,11 +51,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '>=2022.9.2'
+  - '==2022.11.1'
 datashader_version:
   - '>0.13,<0.14'
 distributed_version:
-  - '>=2022.9.2'
+  - '==2022.11.1'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:


### PR DESCRIPTION
This PR pins `dask` and `distributed` to `2022.11.1` for `22.12` release.

needed for https://github.com/rapidsai/cudf/pull/12165