### PR TITLE
Update `xgboost` to `1.7.1`

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -9,7 +9,7 @@ dask_xgboost_version:
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
   # Minor version is appended in meta.yaml
-  - '=1.6.2dev.rapidsai'
+  - '=1.7.1dev.rapidsai'
 
 # Versions for conda
 conda_version:


### PR DESCRIPTION
Now that the `1.7.1` packages are published for `23.02`, this PR updates the version of `xgboost` to `1.7.1`.

See: https://anaconda.org/rapidsai-nightly/xgboost/files?version=1.7.1dev.rapidsai23.02