### PR TITLE
Revert "[REVIEW] Unpin `dask` and `distributed` for development"

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -51,11 +51,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '>=2022.12.0'
+  - '==2022.11.1'
 datashader_version:
   - '>0.13,<0.14'
 distributed_version:
-  - '>=2022.12.0'
+  - '==2022.11.1'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:


### PR DESCRIPTION
Reverts rapidsai/integration#570

Reverting this change until Dec 7th