### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -45,7 +45,6 @@ requirements:
     - numpy {{ numpy_version }}
     - nvtx {{ nvtx_version }}
     - python
-    - setuptools {{ setuptools_version }}
     - cudf ={{ minor_version }}.*
     - cugraph ={{ minor_version }}.*
     - cuml ={{ minor_version }}.*

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -162,7 +162,7 @@ scikit_learn_version:
 scipy_version:
   - '=1.6.0'
 setuptools_version:
-  - '>50'
+  - '>65'
 spdlog_version:
   - '>=1.8.5,<1.9'
 sphinx_markdown_tables_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -51,11 +51,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '>=2022.9.2'
+  - '==2022.11.1'
 datashader_version:
   - '>0.13,<0.14'
 distributed_version:
-  - '>=2022.9.2'
+  - '==2022.11.1'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -168,7 +168,7 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=3.0.0'
+  - '=3.0.1'
 transformers_version:
   - '<=4.10.3'
 ucx_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.