### PR TITLE
Use `setuptools` pin

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -138,7 +138,7 @@ requirements:
     - rapidjson {{ rapidjson_version }}
     - ripgrep
     - s3fs {{ s3fs_version }}
-    - setuptools
+    - setuptools {{ setuptools_version }}
     - scikit-build {{ scikit_build_version }}
     - scikit-image {{ scikit_image_version }}
     - scikit-learn {{ scikit_learn_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -127,7 +127,7 @@ pandas_version:
 pandoc_version:
   - '<=2.0.0'
 panel_version:
-  - '>=0.12.7,<0.13'
+  - '>=0.14.0,<0.15'
 pillow_version:
   - '>=9.0.0'
 pydeck_version:


### PR DESCRIPTION
Follow-up to #573. Apparently the `setuptools_version` variable wasn't being used by `rapids-build-env` already :man_facepalming:.