### PR TITLE
Update protobuf to 4.21

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -36,7 +36,6 @@ requirements:
   host:
     - python
   run:
-    - arrow-cpp {{ arrow_version }}
     - asvdb
     - autoconf
     - automake
@@ -88,6 +87,7 @@ requirements:
     - hypothesis
     - isort {{ isort_version }}
     - lapack
+    - libarrow {{ arrow_version }}
     - libcypher-parser
     - liblapack
     - librdkafka {{ librdkafka_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -27,7 +27,7 @@ sysroot_version:
 
 # Shared versions across meta-pkgs
 arrow_version:
-  - '=9'
+  - '=10'
 benchmark_version:
   - '=1.5.1'
 black_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -139,7 +139,7 @@ python_confluent_kafka_version:
 pytorch_version:
   - '>=1.6,<1.12.0'
 protobuf_version:
-  - '>=3.20.1,<3.21.0a0'
+  - '=4.21'
 pydata_sphinx_theme_version:
   - '>=0.6.3'
 pyproj_version:


### PR DESCRIPTION
Upgrades protobuf to 4.21 to align with libprotobuf 3.21 which is the current conda-forge pinning. https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml#L490-L491
