### PR TITLE
Bump xgboost version to 1.7.1 for 22.12

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -9,7 +9,7 @@ dask_xgboost_version:
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
   # Minor version is appended in meta.yaml
-  - '=1.6.2dev.rapidsai'
+  - '=1.7.1dev.rapidsai'
 
 # Versions for conda
 conda_version:


### PR DESCRIPTION
We bumped the version of xgboost to 1.7.1 for RAPIDS v22.12

Ref: https://anaconda.org/rapidsai/xgboost/files?version=1.7.1dev.rapidsai22.12