### PR TITLE
Adds thriftpy2, needed by cugraph-service

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -148,6 +148,7 @@ requirements:
     - statsmodels
     - streamz
     - sysroot_{{ target_platform }} {{ sysroot_version }}
+    - thriftpy2
     - tomli  # [py<311]
     - transformers {{ transformers_version }}
     - treelite {{ treelite_version }}


### PR DESCRIPTION
Adds `thriftpy2`, which is needed by `cugraph-service-server` and `cugraph-service-client`.