### PR TITLE
Revert "Revert "Update protobuf to 4.21 and arrow to 10""

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -36,7 +36,6 @@ requirements:
   host:
     - python
   run:
-    - arrow-cpp {{ arrow_version }}
     - asvdb
     - autoconf
     - automake
@@ -88,6 +87,7 @@ requirements:
     - hypothesis
     - isort {{ isort_version }}
     - lapack
+    - libarrow {{ arrow_version }}
     - libcypher-parser
     - liblapack
     - librdkafka {{ librdkafka_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -27,7 +27,7 @@ sysroot_version:
 
 # Shared versions across meta-pkgs
 arrow_version:
-  - '=9'
+  - '=10'
 benchmark_version:
   - '=1.5.1'
 black_version:
@@ -139,7 +139,7 @@ python_confluent_kafka_version:
 pytorch_version:
   - '>=1.6,<1.12.0'
 protobuf_version:
-  - '>=3.20.1,<3.21.0a0'
+  - '=4.21'
 pydata_sphinx_theme_version:
   - '>=0.6.3'
 pyproj_version:


### PR DESCRIPTION
Reverts #583.

This PR re-adds the `arrow` 10 and `protobuf` updates.

It should not be merged before https://github.com/rapidsai/cudf/pull/12327.

Keeping as draft until then.