### PR TITLE
Replace Python 3.9 with 3.10

### DIFF
--- a/ci/axis/nightly-env-arm64.yaml
+++ b/ci/axis/nightly-env-arm64.yaml
@@ -14,6 +14,6 @@ CUDA_VER:
 
 PYTHON_VER:
   - 3.8
-  - 3.9
+  - 3.10
 
 exclude:

--- a/ci/axis/nightly-env-arm64.yaml
+++ b/ci/axis/nightly-env-arm64.yaml
@@ -14,6 +14,6 @@ CUDA_VER:
 
 PYTHON_VER:
   - 3.8
-  - 3.10
+  - '3.10'
 
 exclude:

--- a/ci/axis/nightly-env.yaml
+++ b/ci/axis/nightly-env.yaml
@@ -14,6 +14,6 @@ CUDA_VER:
 
 PYTHON_VER:
   - 3.8
-  - 3.9
+  - 3.10
 
 exclude:

--- a/ci/axis/nightly-env.yaml
+++ b/ci/axis/nightly-env.yaml
@@ -14,6 +14,6 @@ CUDA_VER:
 
 PYTHON_VER:
   - 3.8
-  - 3.10
+  - '3.10'
 
 exclude:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -109,7 +109,7 @@ nbsphinx_version:
 nccl_version:
   - '>=2.9.9,<3.0a0'
 networkx_version:
-  - '>=2.5.1,<=2.6.3'
+  - '>=2.5.1'
 nlohmann_json_version:
   - '3.9.1'
 nodejs_version:
@@ -147,7 +147,7 @@ pyproj_version:
 pyppeteer_version:
   - '>=0.2.6'
 pytest_asyncio_version:
-  - '<0.14.0'
+  - '=0.20.*'
 rapidjson_version:
   - '=1.1.0'
 s3fs_version:
@@ -157,10 +157,10 @@ scikit_build_version:
 scikit_image_version:
   - '>=0.19.0,<0.20.0'
 scikit_learn_version:
-  - '=0.24'
+  - '>=0.24'
 # when scipy is updated, remove upper bound on networkx ver.
 scipy_version:
-  - '=1.6.0'
+  - '>=1.6.0'
 setuptools_version:
   - '>65'
 spdlog_version:


### PR DESCRIPTION
Updates the environments to Python 3.10 and removes 3.9. The meta packages are not updated yet since we need Python 3.10 versions of the RAPIDS libraries. That update will be a separate PR.

Need to update the versions of `pytest-asyncio`, `networkx`, `scipy`, and `scikit-learn` to use newer versions that have 3.10 support. I don't think this will impact anything since no library have bounds on `pytest-asyncio`, `scipy`, and `scikit-learn`. `cugraph` has the [same lower bound](https://github.com/rapidsai/cugraph/blob/branch-23.02/dependencies.yaml#L98) on `networkx`.