### PR TITLE
Readd Python 3.9 builds

### DIFF
--- a/ci/axis/nightly-env-arm64.yaml
+++ b/ci/axis/nightly-env-arm64.yaml
@@ -14,6 +14,7 @@ CUDA_VER:
 
 PYTHON_VER:
   - 3.8
+  - 3.9
   - '3.10'
 
 exclude:

--- a/ci/axis/nightly-env.yaml
+++ b/ci/axis/nightly-env.yaml
@@ -14,6 +14,7 @@ CUDA_VER:
 
 PYTHON_VER:
   - 3.8
+  - 3.9
   - '3.10'
 
 exclude:


### PR DESCRIPTION
No Python 3.9 builds for `rapids-build-env` is blocking building the devel containers. See [here](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/docker/job/rapidsai-core-devel/1802/BUILD_IMAGE=rapidsai%2Frapidsai-core-dev-nightly,CUDA_VER=11.5,FROM_IMAGE=gpuci%2Frapidsai,IMAGE_TYPE=devel,LINUX_VER=ubuntu18.04,PYTHON_VER=3.9,RAPIDS_VER=23.02/console). So re-add them until we are ready for fully transition all of the repos.