### PR TITLE
Forward-merge branch-23.02 to branch-23.04

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -83,7 +83,7 @@ gmock_version:
 gtest_version:
   - '=1.10.0'
 holoviews_version:
-  - '>1.14.1,<=1.14.6'
+  - '>=1.14.8,<=1.15.3'
 ipython_version:
   - '=7.31.1'
 isort_version:
@@ -127,7 +127,7 @@ pandas_version:
 pandoc_version:
   - '<=2.0.0'
 panel_version:
-  - '>=0.14.0,<0.15'
+  - '>=0.14.0,<=0.14.1'
 pillow_version:
   - '>=9.0.0'
 pydeck_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -168,7 +168,7 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=3.0.1'
+  - '=3.1.0'
 transformers_version:
   - '<=4.10.3'
 ucx_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.02` that creates a PR to keep `branch-23.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.