### PR TITLE
Update isort version to 5.12.0

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -87,7 +87,7 @@ holoviews_version:
 ipython_version:
   - '=7.31.1'
 isort_version:
-  - '=5.10.1'
+  - '=5.12.0'
 jupyterlab_version:
   - '>=3.1.4,<4.0a0'
 jupyter_packaging_version:


### PR DESCRIPTION
poetry version 1.5.0 broke installs of isort prior to 5.11.5 (see pycqa/isort#2077 and pycqa/isort#2078), so we need to upgrade. Update in line with changes to the pre-commit environment.