### PR TITLE
Forward-merge branch-23.02 to branch-23.04

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -87,7 +87,7 @@ holoviews_version:
 ipython_version:
   - '=7.31.1'
 isort_version:
-  - '=5.10.1'
+  - '=5.12.0'
 jupyterlab_version:
   - '>=3.1.4,<4.0a0'
 jupyter_packaging_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -157,7 +157,7 @@ scikit_build_version:
 scikit_image_version:
   - '>=0.19.0,<0.20.0'
 scikit_learn_version:
-  - '>=0.24'
+  - '=1.2'
 # when scipy is updated, remove upper bound on networkx ver.
 scipy_version:
   - '>=1.6.0'


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.02` that creates a PR to keep `branch-23.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.