### PR TITLE
Adds CUDA 11.8 & Python 3.10 to meta packages

### DIFF
--- a/ci/axis/nightly-env-arm64.yaml
+++ b/ci/axis/nightly-env-arm64.yaml
@@ -14,7 +14,6 @@ CUDA_VER:
 
 PYTHON_VER:
   - 3.8
-  - 3.9
   - '3.10'
 
 exclude:

--- a/ci/axis/nightly-env.yaml
+++ b/ci/axis/nightly-env.yaml
@@ -14,7 +14,6 @@ CUDA_VER:
 
 PYTHON_VER:
   - 3.8
-  - 3.9
   - '3.10'
 
 exclude:

--- a/ci/axis/nightly-meta-arm64.yaml
+++ b/ci/axis/nightly-meta-arm64.yaml
@@ -10,10 +10,11 @@ RAPIDS_VER:
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
-  - 11.5.1
+  - 11.8.0
 
 PYTHON_VER:
   - 3.8
   - 3.9
+  - '3.10'
 
 exclude:

--- a/ci/axis/nightly-meta-arm64.yaml
+++ b/ci/axis/nightly-meta-arm64.yaml
@@ -14,7 +14,6 @@ CUDA_VER:
 
 PYTHON_VER:
   - 3.8
-  - 3.9
   - '3.10'
 
 exclude:

--- a/ci/axis/nightly-meta.yaml
+++ b/ci/axis/nightly-meta.yaml
@@ -10,10 +10,11 @@ RAPIDS_VER:
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
-  - 11.5.1
+  - 11.8.0
 
 PYTHON_VER:
   - 3.8
   - 3.9
+  - '3.10'
 
 exclude:

--- a/ci/axis/nightly-meta.yaml
+++ b/ci/axis/nightly-meta.yaml
@@ -14,7 +14,6 @@ CUDA_VER:
 
 PYTHON_VER:
   - 3.8
-  - 3.9
   - '3.10'
 
 exclude:

--- a/ci/axis/release-arm64.yaml
+++ b/ci/axis/release-arm64.yaml
@@ -10,10 +10,11 @@ RAPIDS_VER:
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
-  - 11.5.1
+  - 11.8.0
 
 PYTHON_VER:
   - 3.8
   - 3.9
+  - '3.10'
 
 exclude:

--- a/ci/axis/release-arm64.yaml
+++ b/ci/axis/release-arm64.yaml
@@ -14,7 +14,6 @@ CUDA_VER:
 
 PYTHON_VER:
   - 3.8
-  - 3.9
   - '3.10'
 
 exclude:

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -10,10 +10,11 @@ RAPIDS_VER:
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:
-  - 11.5.1
+  - 11.8.0
 
 PYTHON_VER:
   - 3.8
   - 3.9
+  - '3.10'
 
 exclude:

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -14,7 +14,6 @@ CUDA_VER:
 
 PYTHON_VER:
   - 3.8
-  - 3.9
   - '3.10'
 
 exclude:


### PR DESCRIPTION
Adds CUDA 11.8 & Python 3.10 to meta packages. Tests are not yet updated since they run on `rapidsai/rapidsai-core-nightly` which doesn't have CUDA 11.8 until after the meta packages are built.