### PR TITLE
Update conda build location

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -88,13 +88,13 @@ function upload_builds {
   else
     gpuci_logger "Upload key found, starting upload..."
     gpuci_logger "Files to upload..."
-    if [[ -n $(ls /conda/conda-bld/${ARCH_DIR}/* | grep -i rapids.*.tar.bz2) ]]; then
-      ls /conda/conda-bld/${ARCH_DIR}/* | grep -i rapids.*.tar.bz2
+    if [[ -n $(ls /tmp/conda-bld-output/${ARCH_DIR}/* | grep -i rapids.*.tar.bz2) ]]; then
+      ls /tmp/conda-bld-output/${ARCH_DIR}/* | grep -i rapids.*.tar.bz2
     fi
 
     gpuci_logger "Starting upload..."
-    if [[ -n $(ls /conda/conda-bld/${ARCH_DIR}/* | grep -i rapids.*.tar.bz2) ]]; then
-      ls /conda/conda-bld/${ARCH_DIR}/* | grep -i rapids.*.tar.bz2 | xargs gpuci_retry \
+    if [[ -n $(ls /tmp/conda-bld-output/${ARCH_DIR}/* | grep -i rapids.*.tar.bz2) ]]; then
+      ls /tmp/conda-bld-output/${ARCH_DIR}/* | grep -i rapids.*.tar.bz2 | xargs gpuci_retry \
         anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai-nightly} --label main --skip-existing --no-progress
     fi
   fi


### PR DESCRIPTION
Now that this repo is using `rapidsai/ci` images to build, the conda build out directory has changed.

See: https://github.com/rapidsai/ci-imgs/blob/main/Dockerfile#L105
Also a [build](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/integration/job/branches/job/branch-meta-pkg-nightly-build/4334/CONDA_CONFIG_FILE=conda%2Frecipes%2Fversions.yaml,CONDA_USERNAME=rapidsai-nightly,CUDA_VER=11.8.0,PYTHON_VER=3.8,RAPIDS_VER=23.02.00a/console#L802)