### PR TITLE
Forward-merge branch-23.02 to branch-23.04

### DIFF
--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -50,9 +50,11 @@ requirements:
     - filterpy
     - holoviews
     - ipython {{ ipython_version }}
+    - ipykernel {{ ipykernel_version }}
     - ipywidgets
     - jupyter-server-proxy
     - jupyterlab {{ jupyterlab_version }}
+    - jupyter_core {{ jupyter_core_version }}
     - jupyterlab-favorites
     - jupyter-packaging {{ jupyter_packaging_version }}
     - jupyterlab_widgets

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -63,7 +63,7 @@ double_conversion_version:
 doxygen_version:
   - '>=1.8.12,<=1.8.20'
 faiss_version:
-  - '=1.7.0'
+  - '=1.7.2'
 fastavro_version:
   - '>=0.22.0'
 flake8_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -86,8 +86,14 @@ holoviews_version:
   - '>=1.14.8,<=1.15.3'
 ipython_version:
   - '=7.31.1'
+# TODO Update ipykernel_version once https://github.com/jupyter-server/jupyter_server/issues/1198 is resolved
+ipykernel_version:
+  - '=6.20.2'
 isort_version:
   - '=5.12.0'
+# TODO Update jupyter_core_version once https://github.com/jupyter-server/jupyter_server/issues/1198 is resolved
+jupyter_core_version:
+  - '=5.1.5'
 jupyterlab_version:
   - '>=3.1.4,<4.0a0'
 jupyter_packaging_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.02` that creates a PR to keep `branch-23.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.