### PR TITLE
Fix `test.yaml` axis

### DIFF
--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -9,15 +9,12 @@ RAPIDS_VER:
   - "23.02"
 
 CUDA_VER:
-  - 11.5
+  - 11.8
 
 LINUX_VER:
-  - ubuntu18.04
-  - ubuntu20.04
-  - centos7
-  - centos8
+  - ubuntu22.04
 
 PYTHON_VER:
-  - 3.8
+  - 3.10
 
 exclude:

--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -15,6 +15,6 @@ LINUX_VER:
   - ubuntu22.04
 
 PYTHON_VER:
-  - 3.10
+  - "3.10"
 
 exclude:


### PR DESCRIPTION
This axis control which `devel` containers get tested on a nightly basis.

Since we've recently reduced our `devel` container matrix, this axis file should be updated to reflect those changes.