### PR TITLE
Fix `dask` pins

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -63,6 +63,7 @@ requirements:
     - gcc_impl_{{ target_platform }}  {{ gcc_version }}
     - cython {{ cython_version }}
     - dask {{ dask_version }}
+    - dask-core {{ dask_version }}
     - dask-ml
     - datashader {{ datashader_version }}
     - distributed {{ distributed_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -51,11 +51,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '=2023.1.1'
+  - '==2023.1.1'
 datashader_version:
   - '>0.13,<0.14'
 distributed_version:
-  - '=2023.1.1'
+  - '==2023.1.1'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:


### PR DESCRIPTION
This PR updates the `dask` and `distributed` pins to match our libraries (e.g. [here](https://github.com/rapidsai/cuml/blob/branch-23.04/conda/recipes/cuml/meta.yaml#L71-L72)).

When only a single `=` sign is used, it is equivalent to `2023.1.1.*`, which causes `conda` to pick up newer nightly packages like `2023.1.1a230127`.

If a newer nightly package gets installed in our base images, it prevents our end-user images from picking up the latest RAPIDS packages which have the `==` pinnings for `dask`.

cc: @galipremsagar 