### PR TITLE
Forward-merge branch-23.02 to branch-23.04

### DIFF
--- a/ci/axis/tests.yaml
+++ b/ci/axis/tests.yaml
@@ -9,15 +9,12 @@ RAPIDS_VER:
   - "23.02"
 
 CUDA_VER:
-  - 11.5
+  - 11.8
 
 LINUX_VER:
-  - ubuntu18.04
-  - ubuntu20.04
-  - centos7
-  - centos8
+  - ubuntu22.04
 
 PYTHON_VER:
-  - 3.8
+  - "3.10"
 
 exclude:

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -63,6 +63,7 @@ requirements:
     - gcc_impl_{{ target_platform }}  {{ gcc_version }}
     - cython {{ cython_version }}
     - dask {{ dask_version }}
+    - dask-core {{ dask_version }}
     - dask-ml
     - datashader {{ datashader_version }}
     - distributed {{ distributed_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -51,11 +51,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '=2023.1.1'
+  - '==2023.1.1'
 datashader_version:
   - '>0.13,<0.14'
 distributed_version:
-  - '=2023.1.1'
+  - '==2023.1.1'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.02` that creates a PR to keep `branch-23.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.