### PR TITLE
Add `dask-core` to `rapids-notebook-env`

### DIFF
--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - cupy {{ cupy_version }}
     - cython {{ cython_version }}
     - dask {{ dask_version }}
+    - dask-core {{ dask_version }}
     - dask-labextension
     - dask-ml
     - datashader {{ datashader_version }}


### PR DESCRIPTION
This will ensure `dask-core` is pinned to the same version as `dask`.

This should've been included in #618.