### PR TITLE
[REVIEW] Upgrade to `arrow-11`

### DIFF
--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - markdown {{ markdown_version }}
     - nbsphinx {{ nbsphinx_version }}
     - numpydoc
-    - pandoc {{ pandoc_version }}
+    - pandoc
     - pydata-sphinx-theme {{ pydata_sphinx_theme_version }}
     - recommonmark
     - sphinx

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -99,7 +99,7 @@ jupyterlab_version:
 jupyter_packaging_version:
   - '>=0.7.0,<0.8'
 librdkafka_version:
-  - '>=1.9.0,<1.10.0a0"
+  - '>=1.9.0,<1.10.0a0'
 markdown_version:
   - '>=3.4.1'
 mimesis_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -130,8 +130,6 @@ openjdk_version:
   - '>=8.0'
 pandas_version:
   - '>=1.0,<1.6.0dev0'
-pandoc_version:
-  - '<=2.0.0'
 panel_version:
   - '>=0.14.0,<=0.14.1'
 pillow_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -99,7 +99,7 @@ jupyterlab_version:
 jupyter_packaging_version:
   - '>=0.7.0,<0.8'
 librdkafka_version:
-  - '=1.7.*'
+  - '>=1.9.0,<1.10.0a0"
 markdown_version:
   - '>=3.4.1'
 mimesis_version:
@@ -139,7 +139,7 @@ pydeck_version:
 pydocstyle_version:
   - '>=6.0.0, <=7.0.0'
 python_confluent_kafka_version:
-  - '>=1.3.0'
+  - '>=1.9.0,<1.10.0a0'
 pytorch_version:
   - '>=1.6,<1.12.0'
 protobuf_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -27,7 +27,7 @@ sysroot_version:
 
 # Shared versions across meta-pkgs
 arrow_version:
-  - '=10'
+  - '=11'
 benchmark_version:
   - '=1.5.1'
 black_version:


### PR DESCRIPTION
This PR upgrades arrow to `11.0` version.

xref: https://github.com/rapidsai/cudf/pull/12757