### PR TITLE
Update ipykernel pin to reject broken multiprocessing releases

### DIFF
--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -56,7 +56,6 @@ requirements:
     - ipywidgets
     - jupyter-server-proxy
     - jupyterlab {{ jupyterlab_version }}
-    - jupyter_core {{ jupyter_core_version }}
     - jupyterlab-favorites
     - jupyter-packaging {{ jupyter_packaging_version }}
     - jupyterlab_widgets

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -86,14 +86,10 @@ holoviews_version:
   - '>=1.14.8,<=1.15.3'
 ipython_version:
   - '=7.31.1'
-# TODO Update ipykernel_version once https://github.com/jupyter-server/jupyter_server/issues/1198 is resolved
 ipykernel_version:
-  - '=6.20.2'
+  - '!=6.21.0,!=6.21.1'
 isort_version:
   - '=5.12.0'
-# TODO Update jupyter_core_version once https://github.com/jupyter-server/jupyter_server/issues/1198 is resolved
-jupyter_core_version:
-  - '=5.1.5'
 jupyterlab_version:
   - '>=3.1.4,<4.0a0'
 jupyter_packaging_version:


### PR DESCRIPTION
As per https://github.com/jupyter-server/jupyter_server/issues/1198 ipykernel version 6.21.0, 6.21.1 were broken when running with multiprocessing module. As of 6.21.2 this is now fixed by https://github.com/ipython/ipykernel/pull/1095 .