### PR TITLE
Add `fmt` and update `spdlog` in `rapids-build-env`

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -75,6 +75,7 @@ requirements:
     - fastavro {{ fastavro_version }}
     - feather-format
     - flake8 {{ flake8_version }}
+    - fmt {{ fmt_version }}
     - fsspec {{ fsspec_version }}
     - gcsfs {{ gcsfs_version }}
     - gdal {{ gdal_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -168,7 +168,7 @@ scipy_version:
 setuptools_version:
   - '>65'
 spdlog_version:
-  - '>=1.8.5,<1.9'
+  - '>=1.11.0,<1.12'
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -68,6 +68,8 @@ fastavro_version:
   - '>=0.22.0'
 flake8_version:
   - '=3.8'
+fmt_version:
+  - '>=9.1.0,<10'
 fsspec_version:
   - '>=0.9.0'
 gdal_version:


### PR DESCRIPTION
This PR adds the `fmt` conda package to `rapids-build-env`. It also updates the `spdlog` version specifier.

These changes are similar to the changes introduced in https://github.com/rapidsai/rmm/pull/1177 and should help resolve the `devel` image build errors that have been occurring lately (e.g. [these](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/docker/job/rapidsai-core-devel/1888/BUILD_IMAGE=rapidsai%2Frapidsai-core-dev-nightly,CUDA_VER=11.8,FROM_IMAGE=gpuci%2Frapidsai,IMAGE_TYPE=devel,LINUX_VER=ubuntu22.04,PYTHON_VER=3.10,RAPIDS_VER=23.04/console)).