### PR TITLE
update datashader version

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -53,7 +53,7 @@ cython_version:
 dask_version:
   - '>=2023.1.1'
 datashader_version:
-  - '>0.13,<0.14'
+  - '>=0.14,<=0.14.4'
 distributed_version:
   - '>=2023.1.1'
 dlpack_version:


### PR DESCRIPTION
This updates `datashader` to match the new version specified in [this PR](https://github.com/rapidsai/cuxfilter/pull/451/files#diff-b34332b9bc59785e2a41231bc82ca7188c42b382ac96d8ed60460fee2342633dL16). The discrepancy caused `cuxfilter` docs builds in jenkins to fail. Logs [here](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/doc-builds/job/docs-build/12124/console#L429).