### PR TITLE
Update minimum `pandas` and `numpy` pinnings

### DIFF
--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - markdown {{ markdown_version }}
     - nbsphinx {{ nbsphinx_version }}
     - numpydoc
-    - pandoc {{ pandoc_version }}
+    - pandoc
     - pydata-sphinx-theme {{ pydata_sphinx_theme_version }}
     - recommonmark
     - sphinx

--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -1,5 +1,6 @@
 # Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
+
 {% set rapids_version = environ.get('RAPIDS_VER', '0.0.0') %}
 {% set minor_version = rapids_version.split('.')[0] + '.' + rapids_version.split('.')[1] %}
 {% set py_version = environ.get('CONDA_PY', 36) %}

--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -1,6 +1,5 @@
 # Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
-
 {% set rapids_version = environ.get('RAPIDS_VER', '0.0.0') %}
 {% set minor_version = rapids_version.split('.')[0] + '.' + rapids_version.split('.')[1] %}
 {% set py_version = environ.get('CONDA_PY', 36) %}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -121,15 +121,13 @@ nodejs_version:
 numba_version:
   - '>=0.56.2'
 numpy_version:
-  - '>=1.19'
+  - '>=1.21'
 nvtx_version:
   - '>=0.2.1,<0.3'
 openjdk_version:
   - '>=8.0'
 pandas_version:
-  - '>=1.0,<1.6.0dev0'
-pandoc_version:
-  - '<=2.0.0'
+  - '>=1.3,<1.6.0dev0'
 panel_version:
   - '>=0.14.0,<=0.14.1'
 pillow_version:


### PR DESCRIPTION
This PR:

 Increments the minimum pinning for pandas version from `1.0` to `1.3`.
 Sets a minimum pinning for `numpy` as `>=1.21`
 Fixes arm conda environment creation by removing `pandoc` version constraint.

xref: https://github.com/rapidsai/cudf/pull/12887