### PR TITLE
Update gcc version to 11

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -21,7 +21,7 @@ conda_verify_version:
 
 # conda compilers
 gcc_version:
-  - 9
+  - 11
 sysroot_version:
   - "2.17"
 


### PR DESCRIPTION
In line with updates to v23.04, we now require gcc 11.

ref: https://github.com/rapidsai/cudf/pull/12868