### PR TITLE
Forward-merge branch-23.04 to branch-23.06

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -21,7 +21,7 @@ conda_verify_version:
 
 # conda compilers
 gcc_version:
-  - 9
+  - 11
 sysroot_version:
   - "2.17"
 

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -170,7 +170,7 @@ spdlog_version:
 sphinx_markdown_tables_version:
   - '=0.0.14=pyh9f0ad1d_1'
 treelite_version:
-  - '=3.1.0'
+  - '=3.2.0'
 transformers_version:
   - '<=4.10.3'
 ucx_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.04` that creates a PR to keep `branch-23.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.