### PR TITLE
[REVIEW] Pin `dask` and `distributed` for release

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -51,11 +51,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '>=2023.1.1'
+  - '==2023.3.2'
 datashader_version:
   - '>=0.14,<=0.14.4'
 distributed_version:
-  - '>=2023.1.1'
+  - '==2023.3.2.1'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:


### PR DESCRIPTION
This PR pins `dask` and `distributed` to `2023.3.2` and `2023.3.2.1` respectively for `23.04` release.

xref: https://github.com/rapidsai/cudf/pull/13070