### PR TITLE
Allow scikit-image 0.20 for cuCIM

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -157,7 +157,7 @@ s3fs_version:
 scikit_build_version:
   - '=0.13.1'
 scikit_image_version:
-  - '>=0.19.0,<0.20.0'
+  - '>=0.19.0,<0.21.0'
 scikit_learn_version:
   - '=1.2'
 # when scipy is updated, remove upper bound on networkx ver.


### PR DESCRIPTION
scikit-image 0.20 was released at the end of Feb, but version constraints currently prevent it from being installed.

We updated cuCIM for consistency with it in the prior 22.12 and 23.02 releases and now that it has been released we should test against it on CI.
