### PR TITLE
Forward-merge branch-23.04 to branch-23.06

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -51,11 +51,11 @@ cupy_version:
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:
-  - '>=2023.1.1'
+  - '==2023.3.2'
 datashader_version:
   - '>=0.14,<=0.14.4'
 distributed_version:
-  - '>=2023.1.1'
+  - '==2023.3.2.1'
 dlpack_version:
   - '>=0.5,<0.6.0a0'
 double_conversion_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -157,7 +157,7 @@ s3fs_version:
 scikit_build_version:
   - '=0.13.1'
 scikit_image_version:
-  - '>=0.19.0,<0.20.0'
+  - '>=0.19.0,<0.21.0'
 scikit_learn_version:
   - '=1.2'
 # when scipy is updated, remove upper bound on networkx ver.


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.04` that creates a PR to keep `branch-23.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.