### PR TITLE
Forward-merge branch-23.04 to branch-23.06

### DIFF
--- a/ci/axis/release-arm64.yaml
+++ b/ci/axis/release-arm64.yaml
@@ -6,7 +6,7 @@ CONDA_CONFIG_FILE:
 
 # Use M.X.Y (major.minor.patch) version to match tag
 RAPIDS_VER:
-  - 23.04.00
+  - 23.04.01
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/ci/axis/release.yaml
+++ b/ci/axis/release.yaml
@@ -6,7 +6,7 @@ CONDA_CONFIG_FILE:
 
 # Use M.X.Y (major.minor.patch) version to match tag
 RAPIDS_VER:
-  - 23.04.00
+  - 23.04.01
 
 # Use CUDA_VER to not clobber `CUDA_VERSION` in the container
 CUDA_VER:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -9,7 +9,7 @@ dask_xgboost_version:
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
   # Minor version is appended in meta.yaml
-  - '=1.7.1dev.rapidsai'
+  - '=1.7.5dev.rapidsai'
 
 # Versions for conda
 conda_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -157,7 +157,7 @@ s3fs_version:
 scikit_build_version:
   - '=0.13.1'
 scikit_image_version:
-  - '>=0.19.0,<0.20.0'
+  - '>=0.19.0,<0.21.0'
 scikit_learn_version:
   - '=1.2'
 # when scipy is updated, remove upper bound on networkx ver.


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.04` that creates a PR to keep `branch-23.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.