### PR TITLE
Add `conda-pack` job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,3 +43,14 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
+  conda-pack:
+    needs: [upload-conda]
+    secrets: inherit
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@branch-23.06
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
+      matrix_filter: map(select(.ARCH == "amd64"))
+      build_script: ci/conda-pack.sh

--- a/ci/conda-pack.sh
+++ b/ci/conda-pack.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 set -e
 
-RAPIDS_VER="23.06a"
+RAPIDS_VER="23.06"
+VERSION_DESCRIPTOR="a"
 CONDA_USERNAME="rapidsai-nightly"
 
 if [ "$GITHUB_REF_TYPE" = "tag" ]; then
-    RAPIDS_VER="23.06"
+    VERSION_DESCRIPTOR=""
     CONDA_USERNAME="rapidsai"
 fi
-
-CONDA_ENV_NAME="rapids${RAPIDS_VER}_cuda${RAPIDS_CUDA_VERSION}_py${RAPIDS_PY_VERSION}"
+CONDA_ENV_NAME="rapids${RAPIDS_VER}${VERSION_DESCRIPTOR}_cuda${RAPIDS_CUDA_VERSION}_py${RAPIDS_PY_VERSION}"
 
 echo "Install conda-pack"
 rapids-mamba-retry install -n base -c conda-forge "conda-pack"

--- a/ci/conda-pack.sh
+++ b/ci/conda-pack.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 set -e
 
-CONDA_ENV_NAME="rapids${RAPIDS_VER}_cuda${CUDA_VER}_py${PYTHON_VER}"
+RAPIDS_VER="23.06a"
+CONDA_USERNAME="rapidsai-nightly"
+
+if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+    RAPIDS_VER="23.06"
+    CONDA_USERNAME="rapidsai"
+fi
+
+CONDA_ENV_NAME="rapids${RAPIDS_VER}_cuda${RAPIDS_CUDA_VERSION}_py${RAPIDS_PY_VERSION}"
 
 echo "Install conda-pack"
 rapids-mamba-retry install -n base -c conda-forge "conda-pack"
@@ -10,8 +18,8 @@ echo "Creating conda environment $CONDA_ENV_NAME"
 rapids-mamba-retry create -y -n $CONDA_ENV_NAME \
     -c $CONDA_USERNAME -c conda-forge -c nvidia \
     "rapids=$RAPIDS_VER" \
-    "cudatoolkit=$CUDA_VER" \
-    "python=$PYTHON_VER"
+    "cudatoolkit=$RAPIDS_CUDA_VERSION" \
+    "python=$RAPIDS_PY_VERSION"
 
 echo "Packing conda environment"
 conda-pack --quiet --ignore-missing-files -n "$CONDA_ENV_NAME" -o "${CONDA_ENV_NAME}.tar.gz"

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -46,3 +46,9 @@ sed_runner "/RAPIDS_VER/{n; s/- .*/- ${NEXT_FULL_TAG}a/}" ci/axis/nightly-meta.y
 sed_runner "/RAPIDS_VER/{n; s/- .*/- ${NEXT_FULL_TAG}/}" ci/axis/release-arm64.yaml
 sed_runner "/RAPIDS_VER/{n; s/- .*/- ${NEXT_FULL_TAG}/}" ci/axis/release.yaml
 sed_runner "/RAPIDS_VER/{n; s/- .*/- \"${NEXT_SHORT_TAG}\"/}" ci/axis/tests.yaml
+
+sed_runner "/RAPIDS_VER=/ s/[0-9][0-9].[0-9][0-9]/${NEXT_SHORT_TAG}/" ci/conda-pack.sh
+
+for FILE in .github/workflows/*.yaml; do
+  sed_runner "/shared-action-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
+done


### PR DESCRIPTION
This PR adds a `conda-pack` job to the `build.yaml` workflow, which I forgot to include in #642.

It also:
- updates the environment variables to reference vars in the new GHAs CI images
- adds some entries to `update-version.sh`