### PR TITLE
Update `xgboost` version

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -9,7 +9,7 @@ dask_xgboost_version:
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
   # Minor version is appended in meta.yaml
-  - '=1.7.1dev.rapidsai'
+  - '=1.7.5dev.rapidsai'
 
 # Versions for conda
 conda_version:


### PR DESCRIPTION
This PR updates `xgboost` to `1.7.5` since it was recently updated: https://github.com/rapidsai/xgboost-conda/pull/65.

The current version of `xgboost` doesn't have Python `3.9` packages, which is causing `conda-pack` to fail for that version: https://github.com/rapidsai/integration/actions/runs/4918223203/jobs/8784624164#step:7:101