### PR TITLE
Update cupy dependency to >=12

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -47,7 +47,7 @@ cmake_setuptools_version:
 cuda_python_version:
   - '>=11.7.1,<12.0'
 cupy_version:
-  - '>=9.5.0,<12.0.0a0'
+  - '>=12.0.0'
 cython_version:
   - '>=0.29.17,<0.30'
 dask_version:


### PR DESCRIPTION
This follows the rest of RAPIDS such as https://github.com/rapidsai/cusignal/pull/570 and https://github.com/rapidsai/cudf/pull/13284