### PR TITLE
Update to numba>=0.57.

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -117,7 +117,7 @@ nlohmann_json_version:
 nodejs_version:
   - '>=14'
 numba_version:
-  - '>=0.56.2'
+  - '>=0.57'
 numpy_version:
   - '>=1.21'
 nvtx_version:


### PR DESCRIPTION
cuDF now requires numba>=0.57.

I am not sure if this change is strictly needed or if cuDF's requirements will automatically enforce the greater lower bound.