### PR TITLE
relax upper version pinning for scikit-image

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -155,7 +155,7 @@ s3fs_version:
 scikit_build_version:
   - '=0.13.1'
 scikit_image_version:
-  - '>=0.19.0,<0.21.0'
+  - '>=0.19.0,<1.0'
 scikit_learn_version:
   - '=1.2'
 # when scipy is updated, remove upper bound on networkx ver.

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -155,7 +155,7 @@ s3fs_version:
 scikit_build_version:
   - '=0.13.1'
 scikit_image_version:
-  - '>=0.19.0,<1.0'
+  - '>=0.19.0,<1.0a0'
 scikit_learn_version:
   - '=1.2'
 # when scipy is updated, remove upper bound on networkx ver.


### PR DESCRIPTION
scikit-image 0.21 will be released soon and we don't want to disallow it being installed alongside cuCIM.

In general scikit-image is trying to release more often, so I chose to just bump the upper pin to the next major version instead.