### PR TITLE
Add CUDA 12 support to rapids metapackage.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   build:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@branch-23.08
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@cuda-120
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -37,7 +37,7 @@ jobs:
   upload-conda:
     needs: [build]
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@branch-23.08
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@cuda-120
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -46,7 +46,7 @@ jobs:
   conda-pack:
     needs: [upload-conda]
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@branch-23.08
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@cuda-120
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,11 +12,11 @@ concurrency:
 jobs:
   build:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@branch-23.08
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@cuda-120
     with:
       build_type: pull-request
   pr-builder:
     needs:
       - build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@branch-23.08
+    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@cuda-120

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - conda-build {{ conda_build_version }}
     - conda-verify {{ conda_verify_version }}
     - cubinlinker  # CUDA enhanced compat.
-    - cuda-python {{ cuda_python_version }}
+    - cuda-python {{ cuda11_cuda_python_version }}
     - cudatoolkit ={{ cuda_major }}.*
     - cupy {{ cupy_version }}
     - c-compiler

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -154,7 +154,7 @@ requirements:
     - werkzeug {{ werkzeug_version }} # Temporary transient dependency pinning to avoid URL-LIB3 + moto timeouts
 
 about:
-  home: http://rapids.ai/
+  home: https://rapids.ai/
   license: Apache-2.0
   license_file: LICENSE
   summary: 'RAPIDS Build Dependencies and Tool Environment Installer'

--- a/conda/recipes/rapids-doc-env/meta.yaml
+++ b/conda/recipes/rapids-doc-env/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - myst-nb
 
 about:
-  home: http://rapids.ai/
+  home: https://rapids.ai/
   license: Apache-2.0
   license_file: LICENSE
   summary: 'RAPIDS Documentation Dependencies and Tool Environment Installer'

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -62,7 +62,7 @@ requirements:
     - umap-learn
 
 about:
-  home: http://rapids.ai/
+  home: https://rapids.ai/
   license: Apache-2.0
   license_file: LICENSE
   summary: 'RAPIDS Notebook Dependencies and Tool Environment Installer'

--- a/conda/recipes/rapids-xgboost/meta.yaml
+++ b/conda/recipes/rapids-xgboost/meta.yaml
@@ -26,8 +26,12 @@ build:
 requirements:
   host:
     - python
+    - cuda-version ={{ cuda_version }}
   run:
-    - cudatoolkit ={{ cuda_major }}.*
+    - {{ pin_compatible('cuda_version', max_pin='x', min_pin='x') }}
+    {% if cuda_major == "11" %}
+    - cudatoolkit
+    {% endif %}
     - nccl {{ nccl_version }}
     - python
     - xgboost {{ xgboost_version }}{{ major_minor_version }}

--- a/conda/recipes/rapids-xgboost/meta.yaml
+++ b/conda/recipes/rapids-xgboost/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - xgboost {{ xgboost_version }}{{ major_minor_version }}
 
 about:
-  home: http://rapids.ai/
+  home: https://rapids.ai/
   license: Custom
   license_file: conda/recipes/rapids-xgboost/LICENSE
   summary: 'RAPIDS + DMLC XGBoost Integration'

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -80,7 +80,7 @@ test:              # [linux64]
     - rmm          # [linux64]
 
 about:
-  home: http://rapids.ai/
+  home: https://rapids.ai/
   license: Custom
   license_file: conda/recipes/rapids/LICENSE
   summary: 'RAPIDS Suite - Open GPU Data Science'

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -26,9 +26,15 @@ build:
 requirements:
   host:
     - python
+    - cuda-version ={{ cuda_version }}
   run:
-    - cuda-python {{ cuda_python_version }}
-    - cudatoolkit ={{ cuda_major }}.*
+    - {{ pin_compatible('cuda_version', max_pin='x', min_pin='x') }}
+    {% if cuda_major == "11" %}
+    - cuda-python {{ cuda11_cuda_python_version }}
+    - cudatoolkit
+    {% else %}
+    - cuda-python {{ cuda12_cuda_python_version }}
+    {% endif %}
     - cupy {{ cupy_version }}
     - nccl {{ nccl_version }}
     - networkx {{ networkx_version }}
@@ -40,7 +46,6 @@ requirements:
     - cugraph ={{ major_minor_version }}.*
     - cuml ={{ major_minor_version }}.*
     - cucim ={{ major_minor_version }}.*
-    - cusignal ={{ major_minor_version }}.*
     - cuspatial ={{ major_minor_version }}.*
     - custreamz ={{ major_minor_version }}.*
     - cuxfilter ={{ major_minor_version }}.*
@@ -49,7 +54,10 @@ requirements:
     - rmm ={{ major_minor_version }}.*
     - pylibcugraph ={{ major_minor_version }}.*
     - libcugraph_etl ={{ major_minor_version }}.*
+    {% if cuda_major == "11" %}
+    - cusignal ={{ major_minor_version }}.*
     - ptxcompiler  # CUDA enhanced compat. See https://github.com/rapidsai/ptxcompiler
+    {% endif %}
     - conda-forge::ucx-proc=*=gpu
     - conda-forge::ucx {{ ucx_version }}
 
@@ -59,8 +67,10 @@ test:              # [linux64]
     - cudf         # [linux64]
     - cudf_kafka   # [linux64]
     - cugraph      # [linux64]
-    - cuml         # [lunux64]
+    - cuml         # [linux64]
+    {% if cuda_major == "11" %}
     - cusignal     # [linux64]
+    {% endif %}
     - cuspatial    # [linux64]
     - custreamz    # [linux64]
     - cuxfilter    # [linux64]

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -44,8 +44,10 @@ cmakelang_version:
   - '=0.6.13'
 cmake_setuptools_version:
   - '>=0.1.3'
-cuda_python_version:
-  - '>=11.7.1,<12.0'
+cuda11_cuda_python_version:
+  - '>=11.7.1,<12.0a'
+cuda12_cuda_python_version:
+  - '>=12.0.0,<13.0a'
 cupy_version:
   - '>=12.0.0'
 cython_version:


### PR DESCRIPTION
This PR updates the `rapids` and `rapids-xgboost` metapackages to support CUDA 12.