### PR TITLE
Temporarily disable cucim and xgboost in CUDA 12 rapids builds.

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -45,12 +45,20 @@ requirements:
     - cudf ={{ major_minor_version }}.*
     - cugraph ={{ major_minor_version }}.*
     - cuml ={{ major_minor_version }}.*
+    {% if cuda_major == "11" %}
+    # Temporarily disabled on CUDA 12 until
+    # https://github.com/rapidsai/cucim/issues/513 is complete
     - cucim ={{ major_minor_version }}.*
+    {% endif %}
     - cuspatial ={{ major_minor_version }}.*
     - custreamz ={{ major_minor_version }}.*
     - cuxfilter ={{ major_minor_version }}.*
     - dask-cuda ={{ major_minor_version }}.*
+    {% if cuda_major == "11" %}
+    # Temporarily disabled on CUDA 12 until
+    # https://github.com/rapidsai/xgboost-feedstock/issues/4 is complete
     - rapids-xgboost ={{ major_minor_version }}.*
+    {% endif %}
     - rmm ={{ major_minor_version }}.*
     - pylibcugraph ={{ major_minor_version }}.*
     - libcugraph_etl ={{ major_minor_version }}.*


### PR DESCRIPTION
Discussed with @raydouglass @vyasr @jakirkham -- temporarily disabling `cucim` and `rapids-xgboost` requirements in `rapids` until their corresponding issues are complete:
- https://github.com/rapidsai/cucim/issues/513
- https://github.com/rapidsai/xgboost-feedstock/issues/4