### PR TITLE
Use cuda-version instead of cudatoolkit for conda pack

### DIFF
--- a/ci/conda-pack.sh
+++ b/ci/conda-pack.sh
@@ -18,7 +18,7 @@ echo "Creating conda environment $CONDA_ENV_NAME"
 rapids-mamba-retry create -y -n $CONDA_ENV_NAME \
     -c $CONDA_USERNAME -c conda-forge -c nvidia \
     "rapids=$RAPIDS_VER" \
-    "cudatoolkit=$RAPIDS_CUDA_VERSION" \
+    "cuda-version=$RAPIDS_CUDA_VERSION" \
     "python=$RAPIDS_PY_VERSION"
 
 echo "Packing conda environment"


### PR DESCRIPTION
Just use the newer `cuda-version` to select the CUDA version. This will pull in the appropriate packaged based on whether it is CUDA 11 or 12.

Fixes: https://github.com/rapidsai/integration/actions/runs/5661037594/job/15338557625#step:7:48