### PR TITLE
Always use `cuda-version` in recipes

### DIFF
--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -25,6 +25,7 @@ build:
 requirements:
   host:
     - python
+    - cuda-version ={{ cuda_version }}
   run:
     - asvdb
     - autoconf
@@ -46,7 +47,10 @@ requirements:
     - conda-verify {{ conda_verify_version }}
     - cubinlinker  # CUDA enhanced compat.
     - cuda-python {{ cuda11_cuda_python_version }}
-    - cudatoolkit ={{ cuda_major }}.*
+    - {{ pin_compatible('cuda_version', max_pin='x', min_pin='x') }}
+    {% if cuda_major == "11" %}
+    - cudatoolkit
+    {% endif %}
     - cupy {{ cupy_version }}
     - c-compiler
     - cxx-compiler

--- a/conda/recipes/rapids-build-env/meta.yaml
+++ b/conda/recipes/rapids-build-env/meta.yaml
@@ -46,10 +46,12 @@ requirements:
     - conda-build {{ conda_build_version }}
     - conda-verify {{ conda_verify_version }}
     - cubinlinker  # CUDA enhanced compat.
-    - cuda-python {{ cuda11_cuda_python_version }}
     - {{ pin_compatible('cuda_version', max_pin='x', min_pin='x') }}
     {% if cuda_major == "11" %}
+    - cuda-python {{ cuda11_cuda_python_version }}
     - cudatoolkit
+    {% else %}
+    - cuda-python {{ cuda12_cuda_python_version }}
     {% endif %}
     - cupy {{ cupy_version }}
     - c-compiler

--- a/conda/recipes/rapids-notebook-env/meta.yaml
+++ b/conda/recipes/rapids-notebook-env/meta.yaml
@@ -25,11 +25,15 @@ build:
 requirements:
   host:
     - python
+    - cuda-version ={{ cuda_version }}
   run:
     - bokeh {{ bokeh_version }}
     - colorcet
     - conda-forge::blas
-    - cudatoolkit ={{ cuda_major }}.*
+    - {{ pin_compatible('cuda_version', max_pin='x', min_pin='x') }}
+    {% if cuda_major == "11" %}
+    - cudatoolkit
+    {% endif %}
     - cupy {{ cupy_version }}
     - cython {{ cython_version }}
     - dask {{ dask_version }}


### PR DESCRIPTION
As `cuda-version` is supported on all CUDA versions, use it constrain CUDA dependence. Only use `cudatoolkit` on CUDA 11 where it is available and not on CUDA 12 where it is gone.