### PR TITLE
Convert CUDA version to major.minor during conda-pack

### DIFF
--- a/ci/conda-pack.sh
+++ b/ci/conda-pack.sh
@@ -9,7 +9,8 @@ if [ "$GITHUB_REF_TYPE" = "tag" ]; then
     VERSION_DESCRIPTOR=""
     CONDA_USERNAME="rapidsai"
 fi
-CONDA_ENV_NAME="rapids${RAPIDS_VER}${VERSION_DESCRIPTOR}_cuda${RAPIDS_CUDA_VERSION}_py${RAPIDS_PY_VERSION}"
+CUDA_VERSION="${RAPIDS_CUDA_VERSION%.*}"
+CONDA_ENV_NAME="rapids${RAPIDS_VER}${VERSION_DESCRIPTOR}_cuda${CUDA_VERSION}_py${RAPIDS_PY_VERSION}"
 
 echo "Install conda-pack"
 rapids-mamba-retry install -n base -c conda-forge "conda-pack"
@@ -18,7 +19,7 @@ echo "Creating conda environment $CONDA_ENV_NAME"
 rapids-mamba-retry create -y -n $CONDA_ENV_NAME \
     -c $CONDA_USERNAME -c conda-forge -c nvidia \
     "rapids=$RAPIDS_VER" \
-    "cuda-version=$RAPIDS_CUDA_VERSION" \
+    "cuda-version=$CUDA_VERSION" \
     "python=$RAPIDS_PY_VERSION"
 
 echo "Packing conda environment"


### PR DESCRIPTION
Should fix the build problem seen here: https://github.com/rapidsai/integration/actions/runs/5681986332/job/15399831914

Filed an issue to follow up on CI for this: https://github.com/rapidsai/integration/issues/671
