### PR TITLE
Add cuProj to the RAPIDS meta package

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -47,6 +47,7 @@ requirements:
     - cuml ={{ major_minor_version }}.*
     - cucim ={{ major_minor_version }}.*
     - cuspatial ={{ major_minor_version }}.*
+    - cuproj ={{ major_minor_version }}.*
     - custreamz ={{ major_minor_version }}.*
     - cuxfilter ={{ major_minor_version }}.*
     - dask-cuda ={{ major_minor_version }}.*


### PR DESCRIPTION
Small PR to add `cuProj` to the RAPIDS metapackages.

Depends on https://github.com/rapidsai/cuspatial/pull/1217