### PR TITLE
Update xgboost version

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -2,8 +2,7 @@
 
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
-  # Minor version is appended in meta.yaml
-  - '=1.7.4'
+  - '=1.7.6'
 
 cuda11_cuda_python_version:
   - '>=11.7.1,<12.0a'


### PR DESCRIPTION
Updating to match the latest build of `xgboost`: https://github.com/rapidsai/xgboost-feedstock/actions/runs/5858796331

Also removes an old comment from before we switched to the feedstock approach.