### PR TITLE
Bump `ucx` to `1.14.0` as a minimum

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -22,4 +22,4 @@ numpy_version:
 nvtx_version:
   - '>=0.2.1,<0.3'
 ucx_version:
-  - '>=1.12.1'
+  - '>=1.14.0'


### PR DESCRIPTION
This version of `ucx` also adds `libnuma` as dependency meaning we can start dropping `libnuma` from Docker images and the like