### PR TITLE
Remove cusignal

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -56,7 +56,6 @@ requirements:
     - pylibcugraph ={{ major_minor_version }}.*
     - libcugraph_etl ={{ major_minor_version }}.*
     {% if cuda_major == "11" %}
-    - cusignal ={{ major_minor_version }}.*
     - ptxcompiler  # CUDA enhanced compat. See https://github.com/rapidsai/ptxcompiler
     {% endif %}
     - conda-forge::ucx-proc=*=gpu


### PR DESCRIPTION
`cusignal` is being archived and integrated into `cupy` instead, so we can remove it from the `rapids` metapackage.

Ref:
- https://docs.rapids.ai/notices/rsn0032/
- https://github.com/rapidsai/actions/pull/31