### PR TITLE
Use `conda mambabuild` not `mamba mambabuild`

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -11,14 +11,14 @@ rapids-print-env
 
 rapids-logger "Build rapids-xgboost"
 
-rapids-mamba-retry mambabuild \
+rapids-conda-retry mambabuild \
   --use-local \
   --variant-config-files "${CONDA_CONFIG_FILE}" \
   conda/recipes/rapids-xgboost
 
 rapids-logger "Build rapids"
 
-rapids-mamba-retry mambabuild \
+rapids-conda-retry mambabuild \
   --use-local \
   --variant-config-files "${CONDA_CONFIG_FILE}" \
   conda/recipes/rapids


### PR DESCRIPTION
With the release of conda 23.7.3, `mamba mambabuild` stopped working. With boa installed, `conda mambabuild` uses the mamba solver, so just use that instead.

See also https://github.com/rapidsai/cudf/issues/14068.
