### PR TITLE
Update UCX pin, remove now redundant `ucx-proc` dependency

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -58,7 +58,6 @@ requirements:
     {% if cuda_major == "11" %}
     - ptxcompiler  # CUDA enhanced compat. See https://github.com/rapidsai/ptxcompiler
     {% endif %}
-    - conda-forge::ucx-proc=*=gpu
     - conda-forge::ucx {{ ucx_version }}
 
 test:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -21,4 +21,4 @@ numpy_version:
 nvtx_version:
   - '>=0.2.1,<0.3'
 ucx_version:
-  - '>=1.12.1'
+  - '>=1.14.1'


### PR DESCRIPTION
Update UCX pin to require `ucx>=1.14.1` and remove the `ucx-proc` dependency which is now redundant as all newer UCX builds include CUDA support.