### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -2,7 +2,7 @@
 
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
-  - '=1.7.6'
+  - '=2.0.3'
 
 cuda11_cuda_python_version:
   - '>=11.7.1,<12.0a'


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.02` that creates a PR to keep `branch-24.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.