### PR TITLE
Remove cuda-python and cudatoolkit from rapids metapackage.

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -29,12 +29,6 @@ requirements:
     - cuda-version ={{ cuda_version }}
   run:
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
-    {% if cuda_major == "11" %}
-    - cuda-python {{ cuda11_cuda_python_version }}
-    - cudatoolkit
-    {% else %}
-    - cuda-python {{ cuda12_cuda_python_version }}
-    {% endif %}
     - cupy {{ cupy_version }}
     - nccl {{ nccl_version }}
     - networkx {{ networkx_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -4,10 +4,6 @@
 xgboost_version:
   - '=2.0.3'
 
-cuda11_cuda_python_version:
-  - '>=11.7.1,<12.0a'
-cuda12_cuda_python_version:
-  - '>=12.0.0,<13.0a'
 cupy_version:
   - '>=12.0.0'
 nccl_version:


### PR DESCRIPTION
We observed that some CUDA packages were being pulled from the `nvidia` channel here: https://github.com/rapidsai/docker/actions/runs/7709797316/job/21011757079#step:9:552

I found that removing `cuda-python` changes the solver behavior in a way that satisfies our needs.

I also removed `cudatoolkit` because that is a transitive dependency of RAPIDS libraries, and only needed for CUDA 11. It is not needed at the top level `rapids` metapackage. Like `cuda-python`, it is constrained by `cuda-version`, so I think it's better to cut it.

Details:

The explicit dependency `rapids -> cuda-python`  is forcing the solver to prefer newer `cuda-python` versions, which in turn makes `cuda-version=12.0` ineffective at constraining `cuda-cudart`. The solver prefers to take `cuda-python 12.3` from conda-forge, but it also has to have `cuda-version 12.0` per our constraints (`cuda-python 12.3` requires `cuda-cudart>=12.3.101,<13.0a0` and `cuda-version>=12.0,<13.0a0`). So then we get `nvidia` channel packages (which are not constrained by `cuda-version`) of `cuda-cudart 12.3` to satisfy `cuda-python 12.3` rather than install `cuda-python 12.0` and get `cuda-cudart` from conda-forge.