### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -29,12 +29,6 @@ requirements:
     - cuda-version ={{ cuda_version }}
   run:
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
-    {% if cuda_major == "11" %}
-    - cuda-python {{ cuda11_cuda_python_version }}
-    - cudatoolkit
-    {% else %}
-    - cuda-python {{ cuda12_cuda_python_version }}
-    {% endif %}
     - cupy {{ cupy_version }}
     - nccl {{ nccl_version }}
     - networkx {{ networkx_version }}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -4,10 +4,6 @@
 xgboost_version:
   - '=2.0.3'
 
-cuda11_cuda_python_version:
-  - '>=11.7.1,<12.0a'
-cuda12_cuda_python_version:
-  - '>=12.0.0,<13.0a'
 cupy_version:
   - '>=12.0.0'
 nccl_version:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.02` that creates a PR to keep `branch-24.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.