### PR TITLE
Adds nx-cugraph to the rapids meta-package

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -31,13 +31,13 @@ requirements:
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
     - cupy {{ cupy_version }}
     - nccl {{ nccl_version }}
-    - networkx {{ networkx_version }}
     - numba {{ numba_version }}
     - numpy {{ numpy_version }}
     - nvtx {{ nvtx_version }}
     - python
     - cudf ={{ major_minor_version }}.*
     - cugraph ={{ major_minor_version }}.*
+    - nx-cugraph ={{ major_minor_version }}.*
     - cuml ={{ major_minor_version }}.*
     - cucim ={{ major_minor_version }}.*
     - cuspatial ={{ major_minor_version }}.*

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -8,8 +8,6 @@ cupy_version:
   - '>=12.0.0'
 nccl_version:
   - '>=2.9.9,<3.0a0'
-networkx_version:
-  - '>=2.5.1'
 numba_version:
   - '>=0.57'
 numpy_version:


### PR DESCRIPTION
* Adds `nx-cugraph` to the `rapids` meta-package - unlike Accelerated Pandas, which is provided with `cudf`, Accelerated NetworkX is not provided with `cugraph` and must be installed separately.
* `nx-cugraph` has a dependency on NetworkX and ensures a compatible version is installed.  Because of this, the explicit install of `networkx` is removed from the `rapids` meta-package in favor of using the `networkx` version installed via `nx-cugraph`.