### PR TITLE
Align ucx version pinning with ucx-py/ucxx.

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -15,4 +15,4 @@ numpy_version:
 nvtx_version:
   - '>=0.2.1,<0.3'
 ucx_version:
-  - '>=1.14.1'
+  - '>=1.15.0,<1.16.0'


### PR DESCRIPTION
As of https://github.com/rapidsai/ucx-py/pull/1032 and https://github.com/rapidsai/ucxx/pull/205, the `ucx` version pinning in RAPIDS has been updated. This PR aligns with those changes.
