### PR TITLE
Update script input name

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,4 +53,4 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       matrix_filter: map(select(.ARCH == "amd64"))
-      build_script: ci/conda-pack.sh
+      script: ci/conda-pack.sh


### PR DESCRIPTION
This PR updates the script inputs in the relevant workflows from `build_script` and `test_script` to `script`. 

Depends on https://github.com/rapidsai/shared-workflows/pull/191
