### PR TITLE
Increase maximum UCX runtime pin to `<1.18.0`

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -15,4 +15,4 @@ numpy_version:
 nvtx_version:
   - '>=0.2.1,<0.3'
 ucx_version:
-  - '>=1.15.0,<1.16.0'
+  - '>=1.15.0,<1.18.0'


### PR DESCRIPTION
Increase maximum UCX runtime pin to support UCX up to `v1.17.x`, but support `v1.15.0` and above until we gain confidence with newer UCX.