### PR TITLE
Update xgboost to 2.1.1

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -2,7 +2,7 @@
 
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
-  - '=2.0.3'
+  - '=2.1.1'
 
 cupy_version:
   - '>=12.0.0'


### PR DESCRIPTION
The xgboost version was increased for `24.08` in https://github.com/rapidsai/xgboost-feedstock/pull/67, so update to match here.