### PR TITLE
Remove NumPy <2 pin

### DIFF
--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -37,19 +37,19 @@ requirements:
     - python
     - cudf ={{ major_minor_version }}.*
     - cuvs ={{ major_minor_version }}.*
-    - cugraph ={{ major_minor_version }}.*
-    - nx-cugraph ={{ major_minor_version }}.*
+    #- cugraph ={{ major_minor_version }}.*
+    #- nx-cugraph ={{ major_minor_version }}.*
     - cuml ={{ major_minor_version }}.*
     - cucim ={{ major_minor_version }}.*
     - cuspatial ={{ major_minor_version }}.*
     - cuproj ={{ major_minor_version }}.*
     - custreamz ={{ major_minor_version }}.*
-    - cuxfilter ={{ major_minor_version }}.*
+    #- cuxfilter ={{ major_minor_version }}.*
     - dask-cuda ={{ major_minor_version }}.*
     - rapids-xgboost ={{ major_minor_version }}.*
     - rmm ={{ major_minor_version }}.*
-    - pylibcugraph ={{ major_minor_version }}.*
-    - libcugraph_etl ={{ major_minor_version }}.*
+    #- pylibcugraph ={{ major_minor_version }}.*
+    #- libcugraph_etl ={{ major_minor_version }}.*
     {% if cuda_major == "11" %}
     - ptxcompiler  # CUDA enhanced compat. See https://github.com/rapidsai/ptxcompiler
     {% endif %}

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -37,19 +37,19 @@ requirements:
     - python
     - cudf ={{ major_minor_version }}.*
     - cuvs ={{ major_minor_version }}.*
-    #- cugraph ={{ major_minor_version }}.*
-    #- nx-cugraph ={{ major_minor_version }}.*
+    - cugraph ={{ major_minor_version }}.*
+    - nx-cugraph ={{ major_minor_version }}.*
     - cuml ={{ major_minor_version }}.*
     - cucim ={{ major_minor_version }}.*
     - cuspatial ={{ major_minor_version }}.*
     - cuproj ={{ major_minor_version }}.*
     - custreamz ={{ major_minor_version }}.*
-    #- cuxfilter ={{ major_minor_version }}.*
+    - cuxfilter ={{ major_minor_version }}.*
     - dask-cuda ={{ major_minor_version }}.*
     - rapids-xgboost ={{ major_minor_version }}.*
     - rmm ={{ major_minor_version }}.*
-    #- pylibcugraph ={{ major_minor_version }}.*
-    #- libcugraph_etl ={{ major_minor_version }}.*
+    - pylibcugraph ={{ major_minor_version }}.*
+    - libcugraph_etl ={{ major_minor_version }}.*
     {% if cuda_major == "11" %}
     - ptxcompiler  # CUDA enhanced compat. See https://github.com/rapidsai/ptxcompiler
     {% endif %}

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -11,7 +11,6 @@ nccl_version:
 numba_version:
   - '>=0.57'
 numpy_version:
-  #- '>=1.23,<3.0a0'
   - '>=2,<3.0a0'
 nvtx_version:
   - '>=0.2.1,<0.3'

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -11,7 +11,8 @@ nccl_version:
 numba_version:
   - '>=0.57'
 numpy_version:
-  - '>=1.23,<3.0a0'
+  #- '>=1.23,<3.0a0'
+  - '>=2,<3.0a0'
 nvtx_version:
   - '>=0.2.1,<0.3'
 ucx_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -15,4 +15,4 @@ numpy_version:
 nvtx_version:
   - '>=0.2.1,<0.3'
 ucx_version:
-  - '>=1.15.0,<1.16.0'
+  - '>=1.15.0,<1.18.0'

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -11,7 +11,7 @@ nccl_version:
 numba_version:
   - '>=0.57'
 numpy_version:
-  - '>=1.23,<2.0a0'
+  - '>=1.23,<3'
 nvtx_version:
   - '>=0.2.1,<0.3'
 ucx_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -11,7 +11,7 @@ nccl_version:
 numba_version:
   - '>=0.57'
 numpy_version:
-  - '>=2,<3.0a0'
+  - '>=1.23,<3.0a0'
 nvtx_version:
   - '>=0.2.1,<0.3'
 ucx_version:

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -11,7 +11,7 @@ nccl_version:
 numba_version:
   - '>=0.57'
 numpy_version:
-  - '>=1.23,<3'
+  - '>=1.23,<3.0a0'
 nvtx_version:
   - '>=0.2.1,<0.3'
 ucx_version:


### PR DESCRIPTION
This PR removes the NumPy<2 pin which is expected to work for
RAPIDS projects once CuPy 13.3.0 is released (CuPy 13.2.0 had
some issues preventing the use with NumPy 2).
