### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   build:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@python-3.12
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -37,7 +37,7 @@ jobs:
   upload-conda:
     needs: [build]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@python-3.12
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -46,7 +46,7 @@ jobs:
   conda-pack:
     needs: [upload-conda]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@python-3.12
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,11 +12,11 @@ concurrency:
 jobs:
   build:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@python-3.12
     with:
       build_type: pull-request
   pr-builder:
     needs:
       - build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@python-3.12

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
       - build
       - test-conda-nightly-env
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@@python-3.12
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@python-3.12
   build:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@python-3.12
@@ -24,7 +24,7 @@ jobs:
   test-conda-nightly-env:
     secrets: inherit
     # We use a build workflow so that we get CPU jobs and high matrix coverage
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@@python-3.12
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@python-3.12
     with:
       build_type: pull-request
       script: "ci/test_conda_nightly_env.sh"

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -54,6 +54,12 @@ requirements:
     - ptxcompiler  # CUDA enhanced compat. See https://github.com/rapidsai/ptxcompiler
     {% endif %}
     - conda-forge::ucx {{ ucx_version }}
+    # TODO: remove pins on pyogrio and tiledb once cuspatial supports 'fmt>11' and 'spdlog>14'
+    # ref:
+    #   * https://github.com/rapidsai/build-planning/issues/56
+    #   * https://github.com/rapidsai/cuspatial/pull/1453#issuecomment-2335527542
+    - pyogrio <0.8
+    - tiledb <2.19
 
 test:
   requires:

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -35,21 +35,22 @@ requirements:
     - numpy {{ numpy_version }}
     - nvtx {{ nvtx_version }}
     - python
-    - cudf ={{ major_minor_version }}.*
-    - cuvs ={{ major_minor_version }}.*
-    - cugraph ={{ major_minor_version }}.*
-    - nx-cugraph ={{ major_minor_version }}.*
-    - cuml ={{ major_minor_version }}.*
-    - cucim ={{ major_minor_version }}.*
-    - cuspatial ={{ major_minor_version }}.*
-    - cuproj ={{ major_minor_version }}.*
-    - custreamz ={{ major_minor_version }}.*
-    - cuxfilter ={{ major_minor_version }}.*
-    - dask-cuda ={{ major_minor_version }}.*
+    # TODO: remove all the floors on specific nightly versions once RAPIDS supports 'fmt>11' and 'spdlog>14'
+    - cudf ={{ major_minor_version }}.*,>=24.10.00a320
+    - cuvs ={{ major_minor_version }}.*,>=24.10.00a60
+    - cugraph ={{ major_minor_version }}.*,>=24.10.00a74
+    - nx-cugraph ={{ major_minor_version }}.*,>=24.10.00a74
+    - cuml ={{ major_minor_version }}.*,>=24.10.00a55
+    - cucim ={{ major_minor_version }}.*,>=24.10.00a17
+    - cuspatial ={{ major_minor_version }}.*,>=24.10.00a41
+    - cuproj ={{ major_minor_version }}.*,>=24.10.00a41
+    - custreamz ={{ major_minor_version }}.*,>=24.10.00a320
+    - cuxfilter ={{ major_minor_version }}.*,>=24.10.00a19
+    - dask-cuda ={{ major_minor_version }}.*,>=24.10.00a19
     - rapids-xgboost ={{ major_minor_version }}.*
-    - rmm ={{ major_minor_version }}.*
-    - pylibcugraph ={{ major_minor_version }}.*
-    - libcugraph_etl ={{ major_minor_version }}.*
+    - rmm ={{ major_minor_version }}.*,>=24.10.00a38
+    - pylibcugraph ={{ major_minor_version }}.*,>=24.10.00a74
+    - libcugraph_etl ={{ major_minor_version }}.*,>=24.10.00a74
     {% if cuda_major == "11" %}
     - ptxcompiler  # CUDA enhanced compat. See https://github.com/rapidsai/ptxcompiler
     {% endif %}


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/40

This PR adds support for Python 3.12.

## Notes for Reviewers

This is part of ongoing work to add Python 3.12 support across RAPIDS.
It temporarily introduces a build/test matrix including Python 3.12, from https://github.com/rapidsai/shared-workflows/pull/213.

A follow-up PR will revert back to pointing at the `branch-24.10` branch of `shared-workflows` once all
RAPIDS repos have added Python 3.12 support.

### This will fail until all dependencies have been updates to Python 3.12

CI here is expected to fail until all of this project's upstream dependencies support Python 3.12.

Blocked by:

* [x] https://github.com/rapidsai/cuml/pull/6060
* [x] https://github.com/rapidsai/cugraph/pull/4647

This can be merged whenever all CI jobs are passing.
