### PR TITLE
DO NOT MERGE: force numpy >=2

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -11,7 +11,7 @@ nccl_version:
 numba_version:
   - '>=0.57'
 numpy_version:
-  - '>=1.23,<2.0a0'
+  - '>=2,<3.0a0'
 nvtx_version:
   - '>=0.2.1,<0.3'
 ucx_version:


### PR DESCRIPTION
This is for testing purposes. Once this PR is passing, it is safe to merge https://github.com/rapidsai/integration/pull/718, which allows numpy range from >=1.23,<3.0a0