### PR TITLE
bump NCCL floor to 2.18.1.1

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -7,7 +7,7 @@ xgboost_version:
 cupy_version:
   - '>=12.0.0'
 nccl_version:
-  - '>=2.9.9,<3.0a0'
+  - '>=2.18.1.1,<3.0a0'
 numba_version:
   - '>=0.57'
 numpy_version:


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/102

Some RAPIDS libraries are using `ncclCommSplit()`, which was introduced in `nccl==2.18.1.1`. This is part of a series of PRs across RAPIDS updating libraries' pins to `nccl>=2.18.1.1` to ensure they get a new-enough version that supports that.
