### PR TITLE
bump NCCL floor to 2.19

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -7,7 +7,7 @@ xgboost_version:
 cupy_version:
   - '>=12.0.0'
 nccl_version:
-  - '>=2.18.1.1,<3.0a0'
+  - '>=2.19,<3.0a0'
 numba_version:
   - '>=0.57'
 numpy_version:


### PR DESCRIPTION
Follow-up to #723

This bumps the NCCL floor here slightly higher, to `>=2.19`. Part of a RAPIDS-wide update of that floor for the 24.10 release. See https://github.com/rapidsai/build-planning/issues/102#issuecomment-2375595743 for context.