### PR TITLE
Quiet conda warnings.

### DIFF
--- a/ci/test_conda_nightly_env.sh
+++ b/ci/test_conda_nightly_env.sh
@@ -21,6 +21,7 @@ rapids-conda-retry \
     cuda-version=${CUDA_VERSION} \
     --dry-run \
     --json \
+    --quiet \
     | tee "${JSON_FILENAME}"
 
 rapids-logger "Parsing results from conda dry-run with rapids=${RAPIDS_VERSION}, python=${RAPIDS_PY_VERSION}, cuda-version=${CUDA_VERSION}"


### PR DESCRIPTION
This fixes failures in the new testing workflow from #690.

**Update:** the root cause was that `rapids-conda-retry` is sending `2>&1`. The warning is being sent to stderr as intended. The old contents are partially incorrect. We can still solve this by providing `--quiet`, without needing to change `rapids-conda-retry`.

<details><summary>Old issue contents</summary>

Output like this is shown, even with the `--json` flag to conda:
```
==> WARNING: A newer version of conda exists. <==
    current version: 24.9.0
    latest version: 24.9.1

Please update conda by running

    $ conda update -n base -c conda-forge conda
```

The only way to make the output "proper JSON" is to pass `--quiet` as well.


This seems like unintentional behavior from conda. The docs from `conda create --help` literally say:
```
--json                Report all output as json. Suitable for using conda programmatically.
```

</details>