### PR TITLE
Update xgboost version to 2.1.2

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -2,7 +2,7 @@
 
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
-  - '=2.1.1'
+  - '=2.1.2'
 
 cupy_version:
   - '>=12.0.0'


### PR DESCRIPTION
Update xgboost to match the feedstock for `25.02`: https://github.com/rapidsai/xgboost-feedstock/blob/main/recipe/meta.yaml#L2