### PR TITLE
Increase UCX upper pin to 1.19

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -13,4 +13,4 @@ numpy_version:
 nvtx_version:
   - '>=0.2.1,<0.3'
 ucx_version:
-  - '>=1.15.0,<1.18.0'
+  - '>=1.15.0,<1.19.0'


### PR DESCRIPTION
Increase upper UCX pin to 1.19 to allow us supporting UCX 1.18 that is needed for RAPIDS 25.02.