### PR TITLE
add pre-commit

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,12 +16,21 @@ jobs:
       - test-conda-nightly-env
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-25.02
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: pre-commit/action@v3.0.1
   build:
+    needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.02
     with:
       build_type: pull-request
   test-conda-nightly-env:
+    needs: checks
     secrets: inherit
     # We use a build workflow so that we get CPU jobs and high matrix coverage
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.02

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+---
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: end-of-file-fixer
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
+  - repo: https://github.com/rapidsai/pre-commit-hooks
+    rev: v0.5.0
+    hooks:
+      - id: verify-copyright

--- a/ci/check_conda_nightly_env.py
+++ b/ci/check_conda_nightly_env.py
@@ -1,6 +1,6 @@
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 import json
 import re
-import subprocess
 import sys
 from datetime import datetime, timedelta
 
@@ -139,7 +139,7 @@ def check_env(json_path):
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Provide only one argument, the filepath to a JSON output from " "conda.")
+        print("Provide only one argument, the filepath to a JSON output from conda.")
         sys.exit(1)
 
     sys.exit(check_env(sys.argv[1]))


### PR DESCRIPTION
Proposes adding a small `pre-commit` configuration to the repo, and a new CI job that runs it.

Motivated by noticing an unused import in this Python code:

https://github.com/rapidsai/integration/blob/172ef624ea50670969e1fd79930a46eabdd9c3c9/ci/check_conda_nightly_env.py#L3

I think this will be helpful to catch the types of things that static analyzers are good at catching.