### PR TITLE
test-conda-nightly-env: remove ucx-proc exclusion

### DIFF
--- a/ci/check_conda_nightly_env.py
+++ b/ci/check_conda_nightly_env.py
@@ -18,8 +18,6 @@ EXCLUDED_PACKAGES = {
     "libxgboost",
     "py-xgboost",
     "xgboost",
-    # TODO: Do we want ucx-proc on rapidsai or from conda-forge?
-    "ucx-proc",
 }
 
 # ANSI color codes used to highlight lines


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/142

Proposes removing the exclusion for `ucx-proc` in the CI job that checks that all projects have produced recent-enough nightlies. See that linked issue for much more detail, but in short:

* there haven't been new `ucx-proc` packages for 2+ years, since https://github.com/conda-forge/ucx-split-feedstock/pull/111
* RAPIDS can safely drop its `ucx-proc` dependency, and other PRs linked to https://github.com/rapidsai/build-planning/issues/142 have done that for the 25.02 release
* `ucx-proc` should not show up in RAPIDS 25.02 environment solves, and so we don't need to carry an exclusion for it in the testing config