### PR TITLE
Update XGBoost to 2.1.4

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -2,7 +2,7 @@
 
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
-  - '=2.1.3'
+  - '=2.1.4'
 
 cupy_version:
   - '>=12.0.0'


### PR DESCRIPTION
Blocked on issue: https://github.com/rapidsai/xgboost-feedstock/issues/79

Updates XGBoost to 2.1.4 with CUDA 12.8 support.

Fixes https://github.com/rapidsai/integration/issues/745