### PR TITLE
Replace `conda-mambabuild` with `conda-build`

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -15,14 +15,14 @@ rapids-print-env
 
 rapids-logger "Build rapids-xgboost"
 
-rapids-conda-retry mambabuild \
+rapids-conda-retry build \
   --use-local \
   --variant-config-files "${CONDA_CONFIG_FILE}" \
   conda/recipes/rapids-xgboost
 
 rapids-logger "Build rapids"
 
-rapids-conda-retry mambabuild \
+rapids-conda-retry build \
   --use-local \
   --variant-config-files "${CONDA_CONFIG_FILE}" \
   conda/recipes/rapids

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -16,14 +16,12 @@ rapids-print-env
 rapids-logger "Build rapids-xgboost"
 
 rapids-conda-retry build \
-  --use-local \
   --variant-config-files "${CONDA_CONFIG_FILE}" \
   conda/recipes/rapids-xgboost
 
 rapids-logger "Build rapids"
 
 rapids-conda-retry build \
-  --use-local \
   --variant-config-files "${CONDA_CONFIG_FILE}" \
   conda/recipes/rapids
 


### PR DESCRIPTION
These are now equivalent in behavior. However support for `conda-mambabuild` is being dropped. So switch to `conda-build`.

xref: https://github.com/rapidsai/build-planning/issues/149