### PR TITLE
Compute matrix for nightly conda environment checks.

### DIFF
--- a/.github/actions/compute-matrix/action.yaml
+++ b/.github/actions/compute-matrix/action.yaml
@@ -1,0 +1,43 @@
+name: Compute matrix
+
+outputs:
+  MATRIX:
+    value: ${{ steps.compute-matrix.outputs.MATRIX }}
+
+runs:
+  using: composite
+  steps:
+    - name: Compute matrix
+      id: compute-matrix
+      shell: bash
+      run: |
+        set -eo pipefail
+
+
+        # please keep the matrices sorted in ascending order by the following:
+        #
+        #     [ARCH, PY_VER, CUDA_VER, LINUX_VER]
+        #
+        export MATRIX="
+        # amd64
+        - { ARCH: 'amd64', PY_VER: '3.10', CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8' }
+        - { ARCH: 'amd64', PY_VER: '3.10', CUDA_VER: '12.8.0', LINUX_VER: 'rockylinux8' }
+        - { ARCH: 'amd64', PY_VER: '3.11', CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8' }
+        - { ARCH: 'amd64', PY_VER: '3.11', CUDA_VER: '12.8.0', LINUX_VER: 'rockylinux8' }
+        - { ARCH: 'amd64', PY_VER: '3.12', CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8' }
+        - { ARCH: 'amd64', PY_VER: '3.12', CUDA_VER: '12.8.0', LINUX_VER: 'rockylinux8' }
+        # arm64
+        - { ARCH: 'arm64', PY_VER: '3.10', CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8' }
+        - { ARCH: 'arm64', PY_VER: '3.10', CUDA_VER: '12.8.0', LINUX_VER: 'rockylinux8' }
+        - { ARCH: 'arm64', PY_VER: '3.11', CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8' }
+        - { ARCH: 'arm64', PY_VER: '3.11', CUDA_VER: '12.8.0', LINUX_VER: 'rockylinux8' }
+        - { ARCH: 'arm64', PY_VER: '3.12', CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8' }
+        - { ARCH: 'arm64', PY_VER: '3.12', CUDA_VER: '12.8.0', LINUX_VER: 'rockylinux8' }
+        "
+
+        MATRIX="$(
+          yq -n -o json 'env(MATRIX)' | \
+          jq -c "${MATRIX_FILTER} | if (. | length) > 0 then {include: .} else \"Error: Empty matrix\n\" | halt_error(1) end"
+        )"
+
+        echo "MATRIX=${MATRIX}" | tee --append "${GITHUB_OUTPUT}"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -42,7 +42,7 @@ jobs:
     with:
       build_type: pull-request
   test-conda-nightly-env:
-    name:  Test conda nightly env: ${{ matrix.CUDA_VER }}, ${{ matrix.PY_VER }}, ${{ matrix.ARCH }}, ${{ matrix.LINUX_VER }}
+    name:  "Test conda nightly env: ${{ matrix.CUDA_VER }}, ${{ matrix.PY_VER }}, ${{ matrix.ARCH }}, ${{ matrix.LINUX_VER }}"
     needs: [checks, compute-matrix]
     strategy:
       fail-fast: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   pr-builder:
     needs:
+      - checks
+      - compute-matrix
       - build
       - test-conda-nightly-env
     secrets: inherit
@@ -23,6 +25,16 @@ jobs:
         with:
           fetch-depth: 1
       - uses: pre-commit/action@v3.0.1
+  compute-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      BUILD_MATRIX: ${{ steps.compute-matrix.outputs.BUILD_MATRIX }}
+      TEST_MATRIX: ${{ steps.compute-matrix.outputs.TEST_MATRIX }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compute Build Matrix
+        id: compute-matrix
+        uses: ./.github/actions/compute-matrix
   build:
     needs: checks
     secrets: inherit
@@ -30,10 +42,14 @@ jobs:
     with:
       build_type: pull-request
   test-conda-nightly-env:
-    needs: checks
+    name:  Test conda nightly env: ${{ matrix.CUDA_VER }}, ${{ matrix.PY_VER }}, ${{ matrix.ARCH }}, ${{ matrix.LINUX_VER }}
+    needs: [checks, compute-matrix]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
+    runs-on: "linux-${{ matrix.ARCH }}-cpu8"
     secrets: inherit
-    # We use a build workflow so that we get CPU jobs and high matrix coverage
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.06
     with:
       build_type: pull-request
-      script: "ci/test_conda_nightly_env.sh"
+      run_script: "ci/test_conda_nightly_env.sh"


### PR DESCRIPTION
Currently CI is failing because we are using `conda-python-build.yaml` for a CPU test job. Some changes were made in https://github.com/rapidsai/shared-workflows/pull/297 that make this workflow less suitable for this generalized usage. Instead, we should compute a custom matrix and use that.
