### PR TITLE
Remove cuspatial and cuproj from rapids metapackage.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,8 +32,11 @@ jobs:
   test-conda-nightly-env:
     needs: checks
     secrets: inherit
-    # We use a build workflow so that we get CPU jobs and high matrix coverage
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
+    # TODO: We want to use a build workflow so that we get CPU jobs and high
+    # matrix coverage without having to hardcode the CUDA/Python matrix here
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.06
     with:
       build_type: pull-request
       script: "ci/test_conda_nightly_env.sh"
+      node_type: "cpu8"
+      container_image: "rapidsai/ci-conda:latest"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,6 +37,6 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.06
     with:
       build_type: pull-request
-      script: "ci/test_conda_nightly_env.sh"
+      run_script: "ci/test_conda_nightly_env.sh"
       node_type: "cpu8"
       container_image: "rapidsai/ci-conda:latest"

--- a/ci/check_conda_nightly_env.py
+++ b/ci/check_conda_nightly_env.py
@@ -37,7 +37,7 @@ def get_package_date(package):
         return None
 
     # Matches 6 digits starting with "2", which should be YYMMDD
-    date_re = r"_(2\d{5})_"
+    date_re = r"(?:^|_)(2\d{5})_"
 
     # Use regex to find the date string in the input
     match = re.search(date_re, package["build_string"])

--- a/conda/recipes/rapids/meta.yaml
+++ b/conda/recipes/rapids/meta.yaml
@@ -41,8 +41,6 @@ requirements:
     - nx-cugraph ={{ major_minor_version }}.*
     - cuml ={{ major_minor_version }}.*
     - cucim ={{ major_minor_version }}.*
-    - cuspatial ={{ major_minor_version }}.*
-    - cuproj ={{ major_minor_version }}.*
     - custreamz ={{ major_minor_version }}.*
     - cuxfilter ={{ major_minor_version }}.*
     - dask-cuda ={{ major_minor_version }}.*


### PR DESCRIPTION
`cuspatial` and `cuproj` can be dropped from the `rapids` metapackage.

See https://docs.rapids.ai/notices/rsn0045/.
