### PR TITLE
test-conda-nightly-env: restore full matrix coverage

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,11 +32,10 @@ jobs:
   test-conda-nightly-env:
     needs: checks
     secrets: inherit
-    # TODO: We want to use a build workflow so that we get CPU jobs and high
-    # matrix coverage without having to hardcode the CUDA/Python matrix here
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.06
+    # We use a build workflow so that we get CPU jobs and high matrix coverage
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
     with:
       build_type: pull-request
-      run_script: "ci/test_conda_nightly_env.sh"
-      node_type: "cpu8"
-      container_image: "rapidsai/ci-conda:latest"
+      script: "ci/test_conda_nightly_env.sh"
+      # just using the workflow to get the matrix, this isn't actually building anything we want to upload
+      upload-artifacts: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,7 +33,7 @@ jobs:
     needs: checks
     secrets: inherit
     # We use a build workflow so that we get CPU jobs and high matrix coverage
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@optional-uploads
     with:
       build_type: pull-request
       script: "ci/test_conda_nightly_env.sh"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,7 +33,7 @@ jobs:
     needs: checks
     secrets: inherit
     # We use a build workflow so that we get CPU jobs and high matrix coverage
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@optional-uploads
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
     with:
       build_type: pull-request
       script: "ci/test_conda_nightly_env.sh"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,3 +21,5 @@ jobs:
     with:
       build_type: pull-request
       script: "ci/test_conda_nightly_env.sh"
+      # just using the workflow to get the matrix, this isn't actually building anything we want to upload
+      upload-artifacts: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,12 @@ repos:
       - id: check-added-large-files
       - id: end-of-file-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.3
+    rev: v0.11.8
     hooks:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.5.0
+    rev: v0.6.0
     hooks:
       - id: verify-copyright


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/shared-workflows/issues/336

Reverts the testing changes from #757, ensuring that `test-conda-nightly-env` tests again run for every platform RAPIDS packages are built for.

And while I'm in here touching this, also updates `pre-commit` hooks to their latest versions with `pre-commit autoupdate`.