### PR TITLE
skip artifact GitHub Actions artifact upload in 'conda-pack' workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,3 +54,5 @@ jobs:
       sha: ${{ inputs.sha }}
       matrix_filter: map(select(.ARCH == "amd64"))
       script: ci/conda-pack.sh
+      # just using the workflow to get the matrix, this isn't actually building anything we want to upload
+      upload-artifacts: false


### PR DESCRIPTION
Follow-up to #760

The `conda-pack` jobs use the `conda-python-build` workflow from `rapidsai/shared-workflows` to get a matrix of build environments. These should also opt out of any attempts to upload things to the GitHub Artifacts store.

This will fix issues like the following seen on branch and nightly builds:

```text
Contents of directory to be uploaded:
ls: cannot access '/tmp/conda-bld-output': No such file or directory
```

([build link](https://github.com/rapidsai/integration/actions/runs/15107055437/job/42458613064))