### PR TITLE
explicitly provide 'script' to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/build_python.sh
       sha: ${{ inputs.sha }}
   upload-conda:
     needs: [build]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -29,6 +29,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
     with:
       build_type: pull-request
+      script: ci/build_python.sh
   test-conda-nightly-env:
     needs: checks
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: check-added-large-files
       - id: end-of-file-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.11.10
     hooks:
       - id: ruff
         args: ["--fix"]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/shared-workflows/issues/356

* explicitly provides an input for `script` to workflows using it, instead of relying on a default value coming from the workflow file

Also updates pre-commit hooks with `pre-commit autoupdate`. Figured it'd be ok to do that while I was already touching the repo anyway.
