### PR TITLE
Allow XGBoost 2 or 3

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -2,7 +2,7 @@
 
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
-  - '=2.1.4'
+  - '=2.1.4|=3.0.2'
 
 cupy_version:
   - '>=12.0.0'


### PR DESCRIPTION
* XGBoost 3 supports CUDA 12 only
* XGBoost 2 supports CUDA 11 & 12
* Allow XGBoost 2 or 3 for users on older CUDA or XGBoost versions