### PR TITLE
WIP: remove cuspatial and cuproj from rapids metapackage

### DIFF
--- a/conda/recipes/rapids/recipe.yaml
+++ b/conda/recipes/rapids/recipe.yaml
@@ -41,8 +41,6 @@ requirements:
     - nx-cugraph ${{ minor_version }}.*
     - cuml ${{ minor_version }}.*
     - cucim ${{ minor_version }}.*
-    - cuspatial ${{ minor_version }}.*
-    - cuproj ${{ minor_version }}.*
     - custreamz ${{ minor_version }}.*
     - cuxfilter ${{ minor_version }}.*
     - dask-cuda ${{ minor_version }}.*


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/197

Removes `cuspatial` and `cuproj` from the runtime dependencies of the `rapids` metapackage. The final releases of those packages were in RAPIDS 25.04.

## Notes for Reviewers

### Didn't we already do this?

Yes, #757 removed this for 25.06 (and that was forward-merged to 25.08).

But it looks like they were accidentally re-introduced in 25.08 via #772

And that technically worked because a small number of `cuspatial` and `cuproj` 25.08 nightlies did make it onto the `rapidsai-nightly` channel before we fully stopped development of `cuspatial`.