### PR TITLE
test-conda-nightly-env: remove cubinlinker and pynvjitlink from configuration

### DIFF
--- a/ci/check_conda_nightly_env.py
+++ b/ci/check_conda_nightly_env.py
@@ -12,8 +12,6 @@ EXCLUDED_PACKAGES = {
     "rapids",
     "rapids-xgboost",
     # These packages do not have date strings:
-    "cubinlinker",
-    "pynvjitlink",
     "rapids-dask-dependency",
     "rapids-logger",  # Also not built every night
     "libxgboost",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/210

`cubinlinker` and `pynvjitlink` should not be showing up in solves for RAPIDS any more as of 25.10.

This removes them from configuration for the `test-conda-nightly-env` CI job.