### PR TITLE
Build and test with CUDA 13.0.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   build:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda13.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -44,7 +44,7 @@ jobs:
   upload-conda:
     needs: [build]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@cuda13.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -53,7 +53,7 @@ jobs:
   conda-pack:
     needs: [upload-conda]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda13.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
       - build
       - test-conda-nightly-env
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@cuda13.0
   checks:
     runs-on: ubuntu-latest
     steps:
@@ -26,7 +26,7 @@ jobs:
   build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda13.0
     with:
       build_type: pull-request
       script: ci/build_python.sh
@@ -34,7 +34,7 @@ jobs:
     needs: checks
     secrets: inherit
     # We use a build workflow so that we get CPU jobs and high matrix coverage
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda13.0
     with:
       build_type: pull-request
       script: "ci/test_conda_nightly_env.sh"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
   test-conda-nightly-env:
     secrets: inherit
     # We use a build workflow so that we get CPU jobs and high matrix coverage
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda13.0
     with:
       build_type: pull-request
       script: "ci/test_conda_nightly_env.sh"

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -12,7 +12,7 @@ jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@cuda13.0
     with:
       sender_login: ${{ github.event.sender.login }}
       sender_avatar: ${{ github.event.sender.avatar_url }}

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -16,12 +16,18 @@ CONDA_CONFIG_FILE="conda/recipes/versions.yaml"
 
 rapids-print-env
 
-rapids-logger "Build rapids-xgboost"
+CUDA_MAJOR="${RAPIDS_CUDA_VERSION%%.*}"
 
-rattler-build build --recipe conda/recipes/rapids-xgboost \
-                    --variant-config "${CONDA_CONFIG_FILE}" \
-                    "${RATTLER_ARGS[@]}" \
-                    "${RATTLER_CHANNELS[@]}"
+# TODO: add rapids-xgboost back when there are CUDA 13 packages
+#  ref: https://github.com/rapidsai/xgboost-feedstock/issues/100
+if [[ "${CUDA_MAJOR}" == "12" ]]; then
+    rapids-logger "Build rapids-xgboost"
+
+    rattler-build build --recipe conda/recipes/rapids-xgboost \
+                        --variant-config "${CONDA_CONFIG_FILE}" \
+                        "${RATTLER_ARGS[@]}" \
+                        "${RATTLER_CHANNELS[@]}"
+fi
 
 rapids-logger "Build rapids"
 

--- a/conda/recipes/rapids/recipe.yaml
+++ b/conda/recipes/rapids/recipe.yaml
@@ -44,7 +44,10 @@ requirements:
     - custreamz ${{ minor_version }}.*
     - cuxfilter ${{ minor_version }}.*
     - dask-cuda ${{ minor_version }}.*
-    - rapids-xgboost ${{ minor_version }}.*
+    # TODO: add rapids-xgboost back when there are CUDA 13 packages
+    #  ref: https://github.com/rapidsai/xgboost-feedstock/issues/100
+    - if: cuda_major == "12"
+      then: rapids-xgboost ${{ minor_version }}.*
     - rmm ${{ minor_version }}.*
     - pylibcugraph ${{ minor_version }}.*
     - libcugraph_etl ${{ minor_version }}.*

--- a/conda/recipes/rapids/recipe.yaml
+++ b/conda/recipes/rapids/recipe.yaml
@@ -44,10 +44,11 @@ requirements:
     - custreamz ${{ minor_version }}.*
     - cuxfilter ${{ minor_version }}.*
     - dask-cuda ${{ minor_version }}.*
-    # TODO: add rapids-xgboost back when there are CUDA 13 packages
+    # TODO: use rapids-xgboost CUDA packages unconditionally when there are CUDA 13 packages
     #  ref: https://github.com/rapidsai/xgboost-feedstock/issues/100
     - if: cuda_major == "12"
       then: rapids-xgboost ${{ minor_version }}.*
+      else: conda-forge::xgboost ${{ xgboost_version }} cpu_*
     - rmm ${{ minor_version }}.*
     - pylibcugraph ${{ minor_version }}.*
     - libcugraph_etl ${{ minor_version }}.*

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -5,7 +5,7 @@ xgboost_version:
   - '=3.0.3'
 
 cupy_version:
-  - '>=12.0.0'
+  - '>=13.6.0'
 nccl_version:
   - '>=2.19,<3.0a0'
 numpy_version:
@@ -13,4 +13,4 @@ numpy_version:
 nvtx_version:
   - '>=0.2.1,<0.3'
 ucx_version:
-  - '>=1.15.0,<1.19.0'
+  - '>=1.15.0,<1.20.0'


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/208

* uses CUDA 13.0.0 to build and test
* moves some dependency pins:
  - `cupy`: `>=13.6.0`

## Notes for Reviewers

This switches GitHub Actions workflows to the `cuda13.0` branch from here: https://github.com/rapidsai/shared-workflows/pull/413

A future round of PRs will revert that back to `branch-25.10`, once all of RAPIDS supports CUDA 13.

### What about XGBoost?

This proposes the following TEMPORARILY for CUDA 13:

* not building `rapids-xgboost` packages
* `rapids` metapackage depending on CPU builds of `xgboost` from conda-forge

This will allow us to start publishing CUDA 13 nightlies of the `rapids` metapackage and other things that depend on it, like the RAPIDS container images (https://github.com/rapidsai/docker/pull/782).