### PR TITLE
temporarily drop cucim from 'rapids' CUDA 12 package

### DIFF
--- a/conda/recipes/rapids/recipe.yaml
+++ b/conda/recipes/rapids/recipe.yaml
@@ -40,9 +40,9 @@ requirements:
     - cugraph ${{ minor_version }}.*
     - nx-cugraph ${{ minor_version }}.*
     - cuml ${{ minor_version }}.*
-    # TODO: put cucim back unconditionally once the issue on CUDA <12.2 environments is resolved
+    # TODO: put cucim back unconditionally once the issue on CUDA <12.2 arm64 environments is resolved
     #  ref: https://github.com/rapidsai/cucim/pull/930
-    - if: cuda_major == "13"
+    - if: cuda_major == "13" or linux64
       then: cucim ${{ minor_version }}.*
     - custreamz ${{ minor_version }}.*
     - cuxfilter ${{ minor_version }}.*

--- a/conda/recipes/rapids/recipe.yaml
+++ b/conda/recipes/rapids/recipe.yaml
@@ -40,7 +40,10 @@ requirements:
     - cugraph ${{ minor_version }}.*
     - nx-cugraph ${{ minor_version }}.*
     - cuml ${{ minor_version }}.*
-    - cucim ${{ minor_version }}.*
+    # TODO: put cucim back unconditionally once the issue on CUDA <12.2 environments is resolved
+    #  ref: https://github.com/rapidsai/cucim/pull/930
+    - if: cuda_major == "13"
+      then: cucim ${{ minor_version }}.*
     - custreamz ${{ minor_version }}.*
     - cuxfilter ${{ minor_version }}.*
     - dask-cuda ${{ minor_version }}.*


### PR DESCRIPTION
`libcucim` is not installable at the moment on arm64 systems with CUDA < 12.2:

* https://github.com/rapidsai/cucim/pull/905/files#r2292609197
* https://github.com/rapidsai/cucim/pull/930

Which is blocking builds of RAPIDS docker images:

* https://github.com/rapidsai/docker/pull/782#issuecomment-3256981010

This proposes **temporarily** excluding `cucim` from the dependencies of arm64 CUDA 12 `rapids` packages, to unblock `docker` CI (and therefore publication of the first CUDA 13 nightlies of those images) until that `cucim` issue is resolved.