### PR TITLE
restore rapids-xgboost dependency, update to xgboost 3.0.5, update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,19 +11,19 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: check-added-large-files
       - id: end-of-file-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.7
+    rev: v0.12.12
     hooks:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
         args: ["--severity=warning"]

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -16,18 +16,12 @@ CONDA_CONFIG_FILE="conda/recipes/versions.yaml"
 
 rapids-print-env
 
-CUDA_MAJOR="${RAPIDS_CUDA_VERSION%%.*}"
+rapids-logger "Build rapids-xgboost"
 
-# TODO: add rapids-xgboost back when there are CUDA 13 packages
-#  ref: https://github.com/rapidsai/xgboost-feedstock/issues/100
-if [[ "${CUDA_MAJOR}" == "12" ]]; then
-    rapids-logger "Build rapids-xgboost"
-
-    rattler-build build --recipe conda/recipes/rapids-xgboost \
-                        --variant-config "${CONDA_CONFIG_FILE}" \
-                        "${RATTLER_ARGS[@]}" \
-                        "${RATTLER_CHANNELS[@]}"
-fi
+rattler-build build --recipe conda/recipes/rapids-xgboost \
+                    --variant-config "${CONDA_CONFIG_FILE}" \
+                    "${RATTLER_ARGS[@]}" \
+                    "${RATTLER_CHANNELS[@]}"
 
 rapids-logger "Build rapids"
 

--- a/conda/recipes/rapids/recipe.yaml
+++ b/conda/recipes/rapids/recipe.yaml
@@ -47,11 +47,7 @@ requirements:
     - custreamz ${{ minor_version }}.*
     - cuxfilter ${{ minor_version }}.*
     - dask-cuda ${{ minor_version }}.*
-    # TODO: use rapids-xgboost CUDA packages unconditionally when there are CUDA 13 packages
-    #  ref: https://github.com/rapidsai/xgboost-feedstock/issues/100
-    - if: cuda_major == "12"
-      then: rapids-xgboost ${{ minor_version }}.*
-      else: conda-forge::xgboost ${{ xgboost_version }} cpu_*
+    - rapids-xgboost ${{ minor_version }}.*
     - rmm ${{ minor_version }}.*
     - pylibcugraph ${{ minor_version }}.*
     - libcugraph_etl ${{ minor_version }}.*

--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -1,8 +1,8 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 
 # Versions for `rapids-xgboost` meta-pkg
 xgboost_version:
-  - '=3.0.3'
+  - '=3.0.5'
 
 cupy_version:
   - '>=13.6.0'


### PR DESCRIPTION
Fixes #798 

Now that @hcho3 has added `xgboost rapidsa_*` packages with CUDA 13 support in https://github.com/rapidsai/xgboost-feedstock/pull/102, we can build `rapids-xgboost` packages with CUDA 13 support here 😁 

This also updates all `pre-commit` hooks with `pre-commit autoupdate`... figured it wouldn't hurt to use this CI run for that little maintenance update too.