### PR TITLE
Restore cuCIM on CUDA 12 ARM

### DIFF
--- a/conda/recipes/rapids/recipe.yaml
+++ b/conda/recipes/rapids/recipe.yaml
@@ -40,10 +40,7 @@ requirements:
     - cugraph ${{ minor_version }}.*
     - nx-cugraph ${{ minor_version }}.*
     - cuml ${{ minor_version }}.*
-    # TODO: put cucim back unconditionally once the issue on CUDA <12.2 arm64 environments is resolved
-    #  ref: https://github.com/rapidsai/cucim/pull/930
-    - if: cuda_major == "13" or linux64
-      then: cucim ${{ minor_version }}.*
+    - cucim ${{ minor_version }}.*
     - custreamz ${{ minor_version }}.*
     - cuxfilter ${{ minor_version }}.*
     - dask-cuda ${{ minor_version }}.*


### PR DESCRIPTION
Previously cuCIM was dropped from CUDA 12 ARM as the packages unconditionally required cuFile, which caused issues when testing with CUDA 12.0 & 12.1. To address this, the cuCIM package was changed to only require cuFile in CUDA 12.2+ ARM packages while creating a separate package for ARM CUDA 12.0 & 12.1, which left out the cuFile dependency. This work was completed in PR: https://github.com/rapidsai/cucim/pull/930

With this change now in place, it should be possible to readd cuCIM to the RAPIDS metapackage generally, which is what this PR does

<hr>

Reverts https://github.com/rapidsai/integration/pull/796
Fixes https://github.com/rapidsai/integration/issues/797