### PR TITLE
Build and test with CUDA 13.2.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   build:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.2.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -45,7 +45,7 @@ jobs:
   upload-conda:
     needs: [build]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@cuda-13.2.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -54,7 +54,7 @@ jobs:
   conda-pack:
     needs: [upload-conda]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.2.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ jobs:
       - check-nightly-ci
       - test-conda-nightly-env
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@cuda-13.2.0
   check-nightly-ci:
     runs-on: ubuntu-latest
     permissions:
@@ -47,7 +47,7 @@ jobs:
   build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.2.0
     with:
       build_type: pull-request
       script: ci/build_python.sh
@@ -56,7 +56,7 @@ jobs:
     needs: checks
     secrets: inherit
     # We use a build workflow so that we get CPU jobs and high matrix coverage
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.2.0
     with:
       build_type: pull-request
       script: "ci/test_conda_nightly_env.sh"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
   test-conda-nightly-env:
     secrets: inherit
     # We use a build workflow so that we get CPU jobs and high matrix coverage
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.2.0
     with:
       build_type: pull-request
       script: "ci/test_conda_nightly_env.sh"
@@ -30,13 +30,13 @@ jobs:
       upload-artifacts: false
   stable-install-pip-test-matrix:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@cuda-13.2.0
     with:
       build_type: nightly
       matrix_name: wheels-test
   test-stable-install-pip:
     needs: stable-install-pip-test-matrix
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.2.0
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.stable-install-pip-test-matrix.outputs.matrix) }}
@@ -49,13 +49,13 @@ jobs:
         ./ci/stable_install/install_and_test_pip.sh --cuda ${{ matrix.CUDA_VER }} --python ${{ matrix.PY_VER }}
   stable-install-conda-test-matrix:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@cuda-13.2.0
     with:
       build_type: nightly
       matrix_name: conda-python-tests
   test-stable-install-conda:
     needs: stable-install-conda-test-matrix
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.2.0
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.stable-install-conda-test-matrix.outputs.matrix) }}

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -12,7 +12,7 @@ jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@cuda-13.2.0
     with:
       sender_login: ${{ github.event.sender.login }}
       sender_avatar: ${{ github.event.sender.avatar_url }}


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/265

* uses CUDA 13.2.0 to build and test
* updates to CUDA 13.2.0 devcontainers

## Notes for Reviewers

This switches GitHub Actions workflows to the `cuda-13.2.0` branch from here: https://github.com/rapidsai/shared-workflows/pull/545

A future round of PRs will revert that back to `main`, once all of RAPIDS is migrated.
