### PR TITLE
fix(ci): resolve all zizmor findings and add zizmor pre-commit checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,5 @@
 name: build
+
 on:
   push:
     branches:
@@ -25,9 +26,13 @@ on:
         description: "build_type: one of [branch, nightly, pull-request]"
         type: string
         default: nightly
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   build:
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,4 @@
 name: build
-
 on:
   push:
     branches:
@@ -26,14 +25,12 @@ on:
         description: "build_type: one of [branch, nightly, pull-request]"
         type: string
         default: nightly
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
-
 jobs:
   build:
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
@@ -42,18 +39,32 @@ jobs:
       script: ci/build_python.sh
       sha: ${{ inputs.sha }}
       pure-conda: cuda_major
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   upload-conda:
     needs: [build]
-    secrets: inherit
+    secrets:
+      CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
+      CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}
     uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   conda-pack:
     needs: [upload-conda]
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
@@ -64,3 +75,9 @@ jobs:
       script: ci/conda-pack.sh
       # just using the workflow to get the matrix, this isn't actually building anything we want to upload
       upload-artifacts: false
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,11 +1,16 @@
 name: pr
+
 on:
   push:
     branches:
       - "pull-request/[0-9]+"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   pr-builder:
     needs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,14 +1,11 @@
 name: pr
-
 on:
   push:
     branches:
       - "pull-request/[0-9]+"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   pr-builder:
     needs:
@@ -16,8 +13,9 @@ jobs:
       - checks
       - check-nightly-ci
       - test-conda-nightly-env
-    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    permissions:
+      contents: read
   check-nightly-ci:
     runs-on: ubuntu-latest
     permissions:
@@ -28,7 +26,7 @@ jobs:
     steps:
       - name: Get PR Info
         id: get-pr-info
-        uses: nv-gha-runners/get-pr-info@main
+        uses: nv-gha-runners/get-pr-info@090577647b8ddc4e06e809e264f7881650ecdccf # main
       - name: Check if nightly CI is passing
         uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
@@ -39,22 +37,31 @@ jobs:
           target-branch: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
   checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
-      - uses: pre-commit/action@v3.0.1
+          persist-credentials: false
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   build:
     needs: checks
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: pull-request
       script: ci/build_python.sh
       pure-conda: cuda_major
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   test-conda-nightly-env:
     needs: checks
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     # We use a build workflow so that we get CPU jobs and high matrix coverage
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
@@ -62,3 +69,9 @@ jobs:
       script: "ci/test_conda_nightly_env.sh"
       # just using the workflow to get the matrix, this isn't actually building anything we want to upload
       upload-artifacts: false
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,5 @@
 name: test
+
 on:
   workflow_dispatch:
     inputs:
@@ -16,6 +17,9 @@ on:
         description: "sha: full git commit SHA to check out"
         required: true
         type: string
+
+permissions: {}
+
 jobs:
   test-conda-nightly-env:
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,4 @@
 name: test
-
 on:
   workflow_dispatch:
     inputs:
@@ -17,10 +16,9 @@ on:
         description: "sha: full git commit SHA to check out"
         required: true
         type: string
-
 jobs:
   test-conda-nightly-env:
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     # We use a build workflow so that we get CPU jobs and high matrix coverage
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
@@ -28,12 +26,19 @@ jobs:
       script: "ci/test_conda_nightly_env.sh"
       # just using the workflow to get the matrix, this isn't actually building anything we want to upload
       upload-artifacts: false
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   stable-install-pip-test-matrix:
-    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@main
     with:
       build_type: nightly
       matrix_name: wheels-test
+    permissions:
+      contents: read
   test-stable-install-pip:
     needs: stable-install-pip-test-matrix
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
@@ -47,12 +52,19 @@ jobs:
       container_image: "rapidsai/citestwheel:26.04-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}-${{ matrix.ARCH }}"
       script: |
         ./ci/stable_install/install_and_test_pip.sh --cuda ${{ matrix.CUDA_VER }} --python ${{ matrix.PY_VER }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   stable-install-conda-test-matrix:
-    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@main
     with:
       build_type: nightly
       matrix_name: conda-python-tests
+    permissions:
+      contents: read
   test-stable-install-conda:
     needs: stable-install-conda-test-matrix
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
@@ -66,3 +78,9 @@ jobs:
       container_image: "rapidsai/ci-conda:26.04-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       script: |
         ./ci/stable_install/install_and_test_conda.sh --cuda ${{ matrix.CUDA_VER }} --python ${{ matrix.PY_VER }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -1,17 +1,16 @@
 name: Trigger Breaking Change Notifications
-
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - closed
       - reopened
       - labeled
       - unlabeled
-
 jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
-    secrets: inherit
+    secrets:
+      NV_SLACK_BREAKING_CHANGE_ALERT: ${{ secrets.NV_SLACK_BREAKING_CHANGE_ALERT }}
     uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main
     with:
       sender_login: ${{ github.event.sender.login }}
@@ -24,3 +23,5 @@ jobs:
       pr_author: ${{ github.event.pull_request.user.login }}
       event_action: ${{ github.event.action }}
       pr_merged: ${{ github.event.pull_request.merged }}
+    permissions:
+      contents: read

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -1,4 +1,5 @@
 name: Trigger Breaking Change Notifications
+
 on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
@@ -6,6 +7,9 @@ on: # zizmor: ignore[dangerous-triggers]
       - reopened
       - labeled
       - unlabeled
+
+permissions: {}
+
 jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # We require SHA-pinning for all workflows and actions _except_ for those from
+        # rapidsai/shared-workflows and rapidsai/shared-actions
+        "rapidsai/shared-workflows/*": any
+        "rapidsai/shared-actions/*": any
+        "*": hash-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: check-added-large-files
       - id: end-of-file-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.9
+    rev: v0.15.13
     hooks:
       - id: ruff
         args: ["--fix"]
@@ -31,3 +31,7 @@ repos:
     rev: v1.4.3
     hooks:
       - id: verify-copyright
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.25.2
+    hooks:
+      - id: zizmor


### PR DESCRIPTION
Similar to upstream changes in `shared-workflows`, this PR cleans up and annotates all of the workflows and adds the `zizmor` linter to make sure changes are checked.

Part of https://github.com/rapidsai/build-planning/issues/275