### PR TITLE
fix(ci): exclude 13.2.0 from stable install testing on 26.04

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,6 +41,8 @@ jobs:
     with:
       build_type: nightly
       matrix_name: wheels-test
+      # TODO: add custom dependency matrix for stable install tests
+      matrix_filter: map(select(.CUDA_VER != "13.2.0"))
     permissions:
       contents: read
   test-stable-install-pip:
@@ -67,6 +69,8 @@ jobs:
     with:
       build_type: nightly
       matrix_name: conda-python-tests
+      # TODO: add custom dependency matrix for stable install tests
+      matrix_filter: map(select(.CUDA_VER != "13.2.0"))
     permissions:
       contents: read
   test-stable-install-conda:


### PR DESCRIPTION
This is a temporary fix for #846 to get the nightly tests passing again.

There is a larger issue around the mismatch between development dependencies in our testing matrix and the dependency matrix at time of release.