### PR TITLE
chore: remove stable install testing from release branch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,10 @@ jobs:
     with:
       build_type: nightly
       matrix_name: wheels-test
+      # TODO: add custom dependency matrix for stable install tests
+      matrix_filter: map(select(.CUDA_VER != "13.2.0"))
+    permissions:
+      contents: read
   test-stable-install-pip:
     needs: stable-install-pip-test-matrix
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.06
@@ -53,6 +57,10 @@ jobs:
     with:
       build_type: nightly
       matrix_name: conda-python-tests
+      # TODO: add custom dependency matrix for stable install tests
+      matrix_filter: map(select(.CUDA_VER != "13.2.0"))
+    permissions:
+      contents: read
   test-stable-install-conda:
     needs: stable-install-conda-test-matrix
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.06

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,7 @@ jobs:
       # just using the workflow to get the matrix, this isn't actually building anything we want to upload
       upload-artifacts: false
   stable-install-pip-test-matrix:
+    if: github.base_ref == 'main'
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@release/26.06
     with:
@@ -52,6 +53,7 @@ jobs:
       script: |
         ./ci/stable_install/install_and_test_pip.sh --cuda ${{ matrix.CUDA_VER }} --python ${{ matrix.PY_VER }}
   stable-install-conda-test-matrix:
+    if: github.base_ref == 'main'
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@release/26.06
     with:


### PR DESCRIPTION
xref #846

We added stable install tests as part of https://github.com/rapidsai/build-planning/issues/226

The purpose of these tests is to ensure that, as the dependency environment shifts around us, that a new (or existing) user who does a fresh install of RAPIDS using our published commands gets something that is usable.

We have a bit of an issue in that the stable install testing environment is always going to lag our development environment, because we want to test things that are a little bit older.

~I have some ideas about how to handle that, but for now, I think there is no reason to keep running these tests on the release branch -- the _exact same tests_ are being run on `main` and those will only change once the 26.06 release is out, at which point we'll start running stable install tests against that version.~

~The other option is to add the same `matrix_filter` that I used in #847 but I think this approach makes more sense in this scenario.~

**edit**: just cherry picking the matrix filter into this PR to avoid forward-merger shenanigans