### PR TITLE
use 'conda' instead of 'mamba' in conda-pack job

### DIFF
--- a/ci/conda-pack.sh
+++ b/ci/conda-pack.sh
@@ -15,10 +15,10 @@ CUDA_VERSION="${RAPIDS_CUDA_VERSION%.*}"
 CONDA_ENV_NAME="rapids${RAPIDS_VER}${VERSION_DESCRIPTOR}_cuda${CUDA_VERSION}_py${RAPIDS_PY_VERSION}"
 
 echo "Install conda-pack"
-rapids-mamba-retry install -n base -c conda-forge "conda-pack"
+rapids-conda-retry install -n base -c conda-forge "conda-pack"
 
 echo "Creating conda environment $CONDA_ENV_NAME"
-rapids-mamba-retry create -y -n $CONDA_ENV_NAME \
+rapids-conda-retry create -y -n $CONDA_ENV_NAME \
     -c $CONDA_USERNAME -c conda-forge \
     "rapids=$RAPIDS_VER" \
     "cuda-version=$CUDA_VERSION" \


### PR DESCRIPTION
During the 26.06 release, some workflows have been broken by stale sharded repodata for the `rapidsai` conda channel.

We put a workaround in place for `conda` and `rattler-build` in https://github.com/rapidsai/shared-workflows/pull/564, but that didn't cover `mamba`.

`mamba`-based operations are failing on the release job here, and it looks like sharded repodata is being used:

```text
...

Resolving Environment                                                                           ⧖ Starting
Resolving Environment                                                                     ✔ Done (6.9 sec)
warning  libmamba The specification of the environment does not seem solvable in your current setup.
...
error    libmamba Could not solve for environment specs
    The following package could not be installed
    └─ rapids =26.6 * is not installable because it conflicts with any installable versions previously reported.
critical libmamba Could not solve for environment specs
```

([build link](https://github.com/rapidsai/integration/actions/runs/27031178890/job/79785460396#step:11:137))

Support for suppressing the use of sharded repodata in `mamba` is very new (https://github.com/mamba-org/mamba/pull/4279), so to avoid needing to rebuild CI images, proposing this PR that just switches `mamba` uses to `conda` for now.