### PR TITLE
remove cuxfilter

### DIFF
--- a/ci/stable_install/install_and_test_conda.sh
+++ b/ci/stable_install/install_and_test_conda.sh
@@ -71,7 +71,6 @@ declare -a RAPIDS_IMPORTS=(
   cugraph
   cuml
   cuvs
-  cuxfilter
   dask_cudf
   nx_cugraph
   pylibraft

--- a/ci/stable_install/install_and_test_pip.sh
+++ b/ci/stable_install/install_and_test_pip.sh
@@ -101,7 +101,6 @@ python -m pip download \
   "cucim-${CUDA_SUFFIX}==${STABLE_RAPIDS_VERSION}" \
   "cugraph-${CUDA_SUFFIX}==${STABLE_RAPIDS_VERSION}" \
   "cuvs-${CUDA_SUFFIX}==${STABLE_RAPIDS_VERSION}" \
-  "cuxfilter-${CUDA_SUFFIX}==${STABLE_RAPIDS_VERSION}" \
   "libcugraph-${CUDA_SUFFIX}==${STABLE_RAPIDS_VERSION}" \
   "libcuvs-${CUDA_SUFFIX}==${STABLE_RAPIDS_VERSION}" \
   "nx-cugraph-${CUDA_SUFFIX}==${STABLE_RAPIDS_VERSION}" \
@@ -124,7 +123,6 @@ declare -a RAPIDS_IMPORTS=(
   cugraph
   cuml
   cuvs
-  cuxfilter
   dask_cudf
   nx_cugraph
   pylibraft

--- a/conda/recipes/rapids/recipe.yaml
+++ b/conda/recipes/rapids/recipe.yaml
@@ -41,7 +41,6 @@ requirements:
     - cuml ${{ minor_version }}.*
     - cucim ${{ minor_version }}.*
     - custreamz ${{ minor_version }}.*
-    - cuxfilter ${{ minor_version }}.*
     - dask-cuda ${{ minor_version }}.*
     - rapids-xgboost ${{ minor_version }}.*
     - rmm ${{ minor_version }}.*


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/291

26.06 was the final release of `cuxfilter`. This removes it from the `rapids` metapackage.

