### PR TITLE
feat(stable install): bump testing version to latest stable release

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,9 @@ jobs:
     with:
       build_type: nightly
       matrix_name: wheels-test
+      # TODO: add custom dependency matrix for stable install tests
+      # Proactively filtering out 13.3 jobs which won't have docker images for the 26.06 release
+      matrix_filter: map(select(.CUDA_VER != "13.3.0"))
     permissions:
       contents: read
   test-stable-install-pip:
@@ -69,6 +72,9 @@ jobs:
     with:
       build_type: nightly
       matrix_name: conda-python-tests
+      # TODO: add custom dependency matrix for stable install tests
+      # Proactively filtering out 13.3 jobs which won't have docker images for the 26.06 release
+      matrix_filter: map(select(.CUDA_VER != "13.3.0"))
     permissions:
       contents: read
   test-stable-install-conda:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,8 +42,6 @@ jobs:
     with:
       build_type: nightly
       matrix_name: wheels-test
-      # TODO: add custom dependency matrix for stable install tests
-      matrix_filter: map(select(.CUDA_VER != "13.2.0"))
     permissions:
       contents: read
   test-stable-install-pip:
@@ -56,7 +54,7 @@ jobs:
       build_type: pull-request
       arch: "${{matrix.ARCH}}"
       node_type: "gpu-${{ matrix.GPU }}-latest-1"
-      container_image: "rapidsai/citestwheel:26.04-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}-${{ matrix.ARCH }}"
+      container_image: "rapidsai/citestwheel:26.06-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}-${{ matrix.ARCH }}"
       script: |
         ./ci/stable_install/install_and_test_pip.sh --cuda ${{ matrix.CUDA_VER }} --python ${{ matrix.PY_VER }}
     permissions:
@@ -71,8 +69,6 @@ jobs:
     with:
       build_type: nightly
       matrix_name: conda-python-tests
-      # TODO: add custom dependency matrix for stable install tests
-      matrix_filter: map(select(.CUDA_VER != "13.2.0"))
     permissions:
       contents: read
   test-stable-install-conda:
@@ -85,7 +81,7 @@ jobs:
       build_type: pull-request
       node_type: "gpu-${{ matrix.GPU }}-latest-1"
       arch: "${{ matrix.ARCH }}"
-      container_image: "rapidsai/ci-conda:26.04-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
+      container_image: "rapidsai/ci-conda:26.06-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       script: |
         ./ci/stable_install/install_and_test_conda.sh --cuda ${{ matrix.CUDA_VER }} --python ${{ matrix.PY_VER }}
     permissions:

--- a/ci/stable_install/install_and_test_conda.sh
+++ b/ci/stable_install/install_and_test_conda.sh
@@ -13,7 +13,7 @@ SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 source "${SCRIPT_DIR}/test_imports.sh"
 source "${SCRIPT_DIR}/install_rapids_doctor.sh"
 
-STABLE_RAPIDS_VERSION="26.4.*"
+STABLE_RAPIDS_VERSION="26.6.*"
 
 while [[ $# -gt 0 ]]; do
   case $1 in

--- a/ci/stable_install/install_and_test_pip.sh
+++ b/ci/stable_install/install_and_test_pip.sh
@@ -13,7 +13,7 @@
 
 set -euo pipefail
 
-STABLE_RAPIDS_VERSION="26.4.*"
+STABLE_RAPIDS_VERSION="26.6.*"
 
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 source "${SCRIPT_DIR}/bootstrap/pip.sh"


### PR DESCRIPTION
Now that the 26.06 release is out, we can bump the version we test nightly in the stable install tests.

This needs better automation overall.
