### PR TITLE
Use main shared-workflows branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ permissions: {}
 jobs:
   build:
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -55,7 +55,7 @@ jobs:
     secrets:
       CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
       CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -70,7 +70,7 @@ jobs:
   conda-pack:
     needs: [upload-conda]
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
       - checks
       - check-nightly-ci
       - test-conda-nightly-env
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
     permissions:
       contents: read
   check-nightly-ci:
@@ -53,7 +53,7 @@ jobs:
   build:
     needs: checks
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: pull-request
       script: ci/build_python.sh
@@ -68,7 +68,7 @@ jobs:
     needs: checks
     secrets: inherit # zizmor: ignore[secrets-inherit]
     # We use a build workflow so that we get CPU jobs and high matrix coverage
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: pull-request
       script: "ci/test_conda_nightly_env.sh"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
   test-conda-nightly-env:
     secrets: inherit # zizmor: ignore[secrets-inherit]
     # We use a build workflow so that we get CPU jobs and high matrix coverage
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: pull-request
       script: "ci/test_conda_nightly_env.sh"
@@ -38,7 +38,7 @@ jobs:
       pull-requests: read
   stable-install-pip-test-matrix:
     if: github.base_ref == 'main'
-    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@main
     with:
       build_type: nightly
       matrix_name: wheels-test
@@ -48,7 +48,7 @@ jobs:
       contents: read
   test-stable-install-pip:
     needs: stable-install-pip-test-matrix
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.stable-install-pip-test-matrix.outputs.matrix) }}
@@ -67,7 +67,7 @@ jobs:
       pull-requests: read
   stable-install-conda-test-matrix:
     if: github.base_ref == 'main'
-    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@main
     with:
       build_type: nightly
       matrix_name: conda-python-tests
@@ -77,7 +77,7 @@ jobs:
       contents: read
   test-stable-install-conda:
     needs: stable-install-conda-test-matrix
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.stable-install-conda-test-matrix.outputs.matrix) }}

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -18,7 +18,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
     permissions:
       contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main
     secrets:
       slack-webhook-url: ${{ secrets.NV_SLACK_BREAKING_CHANGE_NOTIFIER_APP }}
     with:


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/286

## Notes for Reviewers

This reverts GitHub Actions workflow references from the CUDA 13.3.0 shared-workflows branch back to main.
